### PR TITLE
Public Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.1"
+          go-version: "1.18.2"
       - name: Install dependencies
         run: |
           go version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,12 @@ jobs:
           # q stands for quiet, r stands for recursive (to include all files and subfolders in Config)
           mkdir Config
           cp -r Config-Shared/* Config
-          cp -r Config-Vanilla/* Config
+          cp -r Config-Standard/* Config
           zip -qr "${{ github.event.repository.name }}.zip" Config ModInfo.xml README.md LICENSE CHANGELOG.md
           rm -rf Config/*
           cp -r Config-Shared/* Config
-          cp -r Config-CrystalHell/* Config
-          zip -qr "${{ github.event.repository.name }}-crystal-hell.zip" Config ModInfo.xml README.md LICENSE CHANGELOG.md
+          cp -r Config-Researcher/* Config
+          zip -qr "${{ github.event.repository.name }}-researcher.zip" Config ModInfo.xml README.md LICENSE CHANGELOG.md
 
           version=$(sed -n '/Version/{s/.*<Version value=\"\(.*\)\"[ ]*\/>.*/\1/;p}' ModInfo.xml)
           echo "version=$version" >> $GITHUB_ENV
@@ -53,7 +53,7 @@ jobs:
           name: ${{ github.event.pull_request.title }}
           body: "${{ github.event.pull_request.body }}"
           generateReleaseNotes: true
-          artifacts: "${{ github.event.repository.name }}.zip, ${{ github.event.repository.name }}-crystal-hell.zip"
+          artifacts: "${{ github.event.repository.name }}.zip, ${{ github.event.repository.name }}-researcher.zip"
           prerelease: ${{ env.prerelease }}
           # if you'd like to review the generated release before publishing it, enable draft mode
           # draft: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.1"
+          go-version: "1.18.2"
       - name: Install dependencies
         run: |
           go version

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 Config
-Config-Vanilla
-Config-CrystalHell
+Config-Standard
+Config-Researcher
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add recipe for enhanced seed crafting by hand
 - rename vanilla->researcher, crystal-hell->standard
 - fix file generation
+- fix schematic recipe unlocks, update hotbox recipe
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - remove seed return chance during harvest
 - add recipe for enhanced seed crafting by hand
+- rename vanilla->researcher, crystal-hell->standard
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2022-05-21
+## [1.0.0] - 2022-05-22
 
 - remove seed return chance during harvest
 - add recipe for enhanced seed crafting by hand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix file generation
 - fix schematic recipe unlocks, update hotbox recipe
 - fix standard recipe unlocks, update hotbox recipe
+- hide fully grown plant types
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename vanilla->researcher, crystal-hell->standard
 - fix file generation
 - fix schematic recipe unlocks, update hotbox recipe
+- fix standard recipe unlocks, update hotbox recipe
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix standard recipe unlocks, update hotbox recipe
 - hide fully grown plant types
 - hide growing plant types
+- fix gracecorn stage 2 model
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - ?
+
+- remove seed return chance during harvest
+
 ## [0.6.0] - 2022-05-19
 
 - remove 25% decrease to crop yield for renewable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0] - ?
 
 - remove seed return chance during harvest
+- add recipe for enhanced seed crafting by hand
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hide growing plant types
 - fix gracecorn stage 2 model
 - set hotbox repair resources
+- resolve issue with explosive trait collision
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove seed return chance during harvest
 - add recipe for enhanced seed crafting by hand
 - rename vanilla->researcher, crystal-hell->standard
+- fix file generation
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hide fully grown plant types
 - hide growing plant types
 - fix gracecorn stage 2 model
+- set hotbox repair resources
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update readme
 - make Thorny and Explosive traits incompatible
 - fix perk level descriptions, add [MOD] indicator
+- fix bonus trait; support for higher lotl levels
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - set hotbox repair resources
 - resolve issue with explosive trait collision
 - update readme
+- make Thorny and Explosive traits incompatible
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix schematic recipe unlocks, update hotbox recipe
 - fix standard recipe unlocks, update hotbox recipe
 - hide fully grown plant types
+- hide growing plant types
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - make Thorny and Explosive traits incompatible
 - fix perk level descriptions, add [MOD] indicator
 - fix bonus trait; support for higher lotl levels
+- fix researcher 2nd trait seed ingredient count
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - resolve issue with explosive trait collision
 - update readme
 - make Thorny and Explosive traits incompatible
+- fix perk level descriptions, add [MOD] indicator
 
 ## [0.6.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - ?
+## [1.0.0] - 2022-05-21
 
 - remove seed return chance during harvest
 - add recipe for enhanced seed crafting by hand
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix gracecorn stage 2 model
 - set hotbox repair resources
 - resolve issue with explosive trait collision
+- update readme
 
 ## [0.6.0] - 2022-05-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to the GMO Farming Modlet Project
+
+This modlet is truly massive due to all the plant traits and supported combinations of them.
+
+Becuase of this, we relied on Go to generate the necessary xpath files to make this modlet work as envisioned.
+
+## Code Structure
+
+This project generates 2 separate themes of this mod that the admin can choose between: Standard and Researcher (find out more about them in the [README](README.md)).
+
+Folder | Purpose
+--- | ---
+Config-Shared | pure, non-generated XML/XPath. Changes made here will show up in both themes
+Config-Researcher | ignored by git, generated
+Config-Standard | ignored by git, generated
+Config | ignored by git, filled by build script
+data | go [data](./data) package responsible for specifics related to traits and plants
+gen | go [gen](./gen) package responsible for generating xml files
+
+- `build-researcher-locally.sh` is a shell script that allows one to build and prepare a local copy of this mod with the Researcher Theme (helpful for local testing).
+- `build-standard-locally.sh` is the same kind of shell script, but for the Standard Theme rather than Researcher.
+
+## Learn Go
+
+If you don't already know Go, you can learn it [over here](https://go.dev/learn/).
+
+I highly recommend the [Tour of Go](https://go.dev/tour/), which can usually get someone up to speed in about 30mins to 1hr.
+
+## More Questions?
+
+Feel free to reach out to me: <https://github.com/jonathan-robertson/gmo-farming/discussions/53>

--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -3,7 +3,7 @@
         <Name value="GMO Farming" />
         <Description value="Genetically modify seeds to grow plants with new properties" />
         <Author value="Shavick and Jonathan Robertson (Kanaverum)" />
-        <Version value="0.6.0" />
+        <Version value="0.7.0b" />
         <Website value="https://github.com/jonathan-robertson/gmo-farming" />
     </ModInfo>
 </xml>

--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -2,8 +2,8 @@
     <ModInfo>
         <Name value="GMO Farming" />
         <Description value="Genetically modify seeds to grow plants with new properties" />
-        <Author value="Shavick and Jonathan Robertson (Kanaverum)" />
-        <Version value="0.7.0b" />
+        <Author value="Jonathan Robertson (Kanaverum) and Shavick" />
+        <Version value="1.0.0" />
         <Website value="https://github.com/jonathan-robertson/gmo-farming" />
     </ModInfo>
 </xml>

--- a/README.md
+++ b/README.md
@@ -4,23 +4,101 @@
 
 7 Days to Die Modlet: Genetically modify seeds to grow plants with new properties
 
+![GMO Farming Image](https://github.com/jonathan-robertson/gmo-farming/raw/media/gmo-farming-social.jpg)
+
+## Compatibility
+
+This modlet is compatible with Servers and Clients in all combinations; examine the chart below for details specific to your situation:
+
+Environment | Compatible? | Details
+:---: | :---: | ---
+Dedicated Server | Yes | This mod is meant for dedicated servers only
+EAC | Yes | You can leave EAC enabled on your server and client
+P2P | Yes | Peer-to-peer multiplayer games only require the **host** to install this mod
+Local | Yes | Installing this mod on the client is fully supported for local games
+
 ## Features
 
-TODO
+*Have you ever wanted to customize your seeds so they can meet your personal needs?*
 
-## Development
+### Seed Enhancement
 
-This modlet is truly massive due to all the plant traits and supported combinations of them.
+With the help of a new workstation (the Hot Box), you'll expose seeds to abnormally high levels of the zombie virus, doubling their crop yield and making them capable of taking on various special traits.
 
-Becuase of this, we relied on Go to generate [blocks.xml](./Config/blocks.xml), [recipes.xml](./Config/recipes.xml), and [Localization.txt](./Config/Localization.txt).
+Trait Name | Description
+:---: | ---
+Bonus | further doubles crop yield (4x yield over unmodified crops)
+Explosive | triggers a concealed explosive [comparable to cooking pot mine] when stepped on, struck with a melee weapon, or hit with an arrow. Due to the flexible nature of plants, the detonator will not trigger if struck with bullets or other explosives
+Fast | reaches maturity in half the time
+Renewable | clean, healthy water allows this plant to spread out its roots and bolster its nutrition absorption and allowing it to produce crops endlessly
+Thorny | integrates with sharp, metal thorns. Touching them will cause one to bleed
+Underground | fused with mushroom dna, allowing growth without the need for sunlight
 
-To make adjustments to generated files:
+#### Trait Compatibility Matrix
 
-1. edit the `*.go` files in the [data](./data) and [gen](./gen) packages to suit your preferences.
-2. run `go run main.go` to have it dump files generated files into the [Config](./Config) folder.
+Traits can also be combined (up to 2), though not all are compatible with one other.
 
-## Learn Go
+|   | B | E | F | R | T | U |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| B | ✅ | 🚫 | ✅ | ✅ | ✅ | ✅ |
+| E | 🚫 | ✅ | ✅ | 🚫 | ✅ | ✅ |
+| F | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| R | ✅ | 🚫 | ✅ | 🚫 | ✅ | ✅ |
+| T | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| U | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫 |
 
-If you don't already know Go, you can learn it [over here](https://go.dev/learn/).
+> *Note that Mushrooms cannot be given the Underground trait because they already have it.*
 
-I highly recommend the [Tour of Go](https://go.dev/tour/), which can usually get someone up to speed in about 30mins to 1hr.
+### Effects of Trait Combination
+
+In situations where two different traits are adopted, the plant will benefit from each trait in equal measure.
+
+But in situations where a trait is doubled, the name of the trait changes in the following ways:
+
+Trait Name | Description
+:---: | ---
+Bountiful Bonus | further ***quadruples*** crop yield (***8x*** yield over unmodified crops)
+Extremely Explosive | triggers a concealed explosive ***with a large payload*** [comparable to hubcap mine] when stepped on, struck with a melee weapon, or hit with an arrow. Due to the flexible nature of plants, the detonator will not trigger if struck with bullets or other explosives
+Rapid Growth | reaches maturity in a ***quarter*** of the time
+Extra Thorny | integrates with ***many*** sharp, metal thorns. Touching them will cause one to bleed ***profusely***
+
+## 2 Different Themes to Choose From
+
+This modlet comes with 2 Themes: `Standard` and `Researcher`. The one you choose for your game or community should be carefully considered.
+
+You can download the Theme you prefer from our [Latest Release](https://github.com/jonathan-robertson/gmo-farming/releases/latest) page by expanding the Assets link to see available downloads.
+
+### `Standard` Experience
+
+This Theme is the most vanilla-friendly experience you can expect from a mod like this:
+
+- players unlock content by leveling up in `Living off the Land`
+- each skill level the player adds after level 2 will unlock new content
+- primary focus of this Theme is to encourage use and expand the base game's content
+
+Fortitude Level Requirement | Living off the Land Level | Adjustment
+:---: | :---: | ---
+5 | 3 | In addition to the existing boost to crop yield, learn to craft a Hot Box (workstation) and Seed Enhancement
+7 | 4 | Learn to add one trait into an Enhanced Seed
+10 | 5 | Learn to add a second trait into a seed that already has its first trait
+
+### `Researcher` Experience
+
+This Theme is more focused on player specialization and giving the player a new challenge to overcome.
+
+- instead of unlocking these new seed recipes by leveling up `Living off the Land`, the player unlock the *opportunity* to learn these new recipes by *researching* them (crafting schematics).
+- such research is time and resource intensive, requiring intentional effort in working towards the player's desired seeds and traits. Naturally, this will be a challenge and require a significant amount of farming.
+- primary focus of this Theme is to provide a difficulty barrier to crafting these new seeds. While the recipes to craft the seeds aren't complicated or challenging, researching them is and this requires players to invest the time if they want the benefit from these enhanced crops. This Theme is also an effort to prevent the GMO Farming mod from totally throwing the game out of whack with easy-to-craft super-crops
+
+Fortitude Level Requirement | Living off the Land Level | Adjustment
+:---: | :---: | ---
+5 | 3 | In addition to the existing boost to crop yield, learn to craft a Hot Box (workstation) and Seed Enhancement ***Schematics***
+7 | 4 | Learn the ***schematics*** to add one trait into an Enhanced Seed
+10 | 5 | Learn the ***schematics*** to add a second trait into a seed that already has its first trait
+
+## Recognition
+
+- Huge recognition for Shavick who spent a lot of time brainstorming and proving out this concept with me!
+  - His input into this project made most of its coolest ideas possible.
+  - He plans to use this mod in his own Overhaul called Crystal Hell [(discord link)](https://discord.gg/xvSgfUJfsG); this mod is only a small piece if the awesome stuff they've got going on over there!
+- Obviously The Fun Pimps for making a fun game to play and mod :]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GMO Farming
 
-[![Tested with A20.4 b42](https://img.shields.io/badge/A20.4%20b42-tested-blue.svg)](https://7daystodie.com/) [![Automated Release](https://github.com/fatal-expedition/nerf-parkour/actions/workflows/main.yml/badge.svg)](https://github.com/jonathan-robertson/gmo-farming/actions/workflows/main.yml)
+[![Tested with A20.5 b2](https://img.shields.io/badge/A20.5%20b2-tested-blue.svg)](https://7daystodie.com/) [![Automated Release](https://github.com/jonathan-robertson/gmo-farming/actions/workflows/main.yml/badge.svg)](https://github.com/jonathan-robertson/gmo-farming/actions/workflows/main.yml)
 
 7 Days to Die Modlet: Genetically modify seeds to grow plants with new properties
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ![GMO Farming Image](https://github.com/jonathan-robertson/gmo-farming/raw/media/gmo-farming-social.jpg)
 
+[Standard Edition Introduction (YouTube)](https://youtu.be/Rlf7xDVKjIE) | [Researcher Edition Differences (YouTube)](https://youtu.be/4QvH_5q_P2g)
+
 ## Compatibility
 
 This modlet is compatible with Servers and Clients in all combinations; examine the chart below for details specific to your situation:
@@ -62,19 +64,19 @@ Extremely Explosive | triggers a concealed explosive ***with a large payload*** 
 Rapid Growth | reaches maturity in a ***quarter*** of the time
 Extra Thorny | integrates with ***many*** sharp, metal thorns. Touching them will cause one to bleed ***profusely***
 
-## 2 Different Themes to Choose From
+## 2 Editions to Choose From
 
-This modlet comes with 2 Themes: `Standard` and `Researcher`. The one you choose for your game or community should be carefully considered.
+This modlet comes with 2 Editions: `Standard` and `Researcher`. The one you choose for your game or community should be carefully considered.
 
-You can download the Theme you prefer from our [Latest Release](https://github.com/jonathan-robertson/gmo-farming/releases/latest) page by expanding the Assets link to see available downloads.
+You can download the Edition you prefer from our [Latest Release](https://github.com/jonathan-robertson/gmo-farming/releases/latest) page by expanding the Assets link to see available downloads.
 
 ### `Standard` Experience
 
-This Theme is the most vanilla-friendly experience you can expect from a mod like this:
+This Edition is the most vanilla-friendly experience you can expect from a mod like this:
 
 - players unlock content by leveling up in `Living off the Land`
 - each skill level the player adds after level 2 will unlock new content
-- primary focus of this Theme is to encourage use and expand the base game's content
+- primary focus of this Edition is to encourage use and expand the base game's content
 
 Fortitude Level Requirement | Living off the Land Level | Adjustment
 :---: | :---: | ---
@@ -84,11 +86,11 @@ Fortitude Level Requirement | Living off the Land Level | Adjustment
 
 ### `Researcher` Experience
 
-This Theme is more focused on player specialization and giving the player a new challenge to overcome.
+This Edition is more focused on player specialization and giving the player a new challenge to overcome.
 
 - instead of unlocking these new seed recipes by leveling up `Living off the Land`, the player unlock the *opportunity* to learn these new recipes by *researching* them (crafting schematics).
 - such research is time and resource intensive, requiring intentional effort in working towards the player's desired seeds and traits. Naturally, this will be a challenge and require a significant amount of farming.
-- primary focus of this Theme is to provide a difficulty barrier to crafting these new seeds. While the recipes to craft the seeds aren't complicated or challenging, researching them is and this requires players to invest the time if they want the benefit from these enhanced crops. This Theme is also an effort to prevent the GMO Farming mod from totally throwing the game out of whack with easy-to-craft super-crops
+- primary focus of this Edition is to provide a difficulty barrier to crafting these new seeds. While the recipes to craft the seeds aren't complicated or challenging, researching them is and this requires players to invest the time if they want the benefit from these enhanced crops. This Edition is also an effort to prevent the GMO Farming mod from totally throwing the game out of whack with easy-to-craft super-crops
 
 Fortitude Level Requirement | Living off the Land Level | Adjustment
 :---: | :---: | ---

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Traits can also be combined (up to 2), though not all are compatible with one ot
 |   | B | E | F | R | T | U |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | B | ✅ | 🚫 | ✅ | ✅ | ✅ | ✅ |
-| E | 🚫 | ✅ | ✅ | 🚫 | ✅ | ✅ |
+| E | 🚫 | ✅ | ✅ | 🚫 | 🚫 | ✅ |
 | F | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | R | ✅ | 🚫 | ✅ | 🚫 | ✅ | ✅ |
-| T | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| T | ✅ | 🚫 | ✅ | ✅ | ✅ | ✅ |
 | U | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫 |
 
 > *Note that Mushrooms cannot be given the Underground trait because they already have it.*

--- a/build-researcher-locally.sh
+++ b/build-researcher-locally.sh
@@ -3,5 +3,5 @@ rm -rf Config
 mkdir Config
 go run .
 cp -r Config-Shared/* Config
-cp -r Config-Vanilla/* Config
+cp -r Config-Researcher/* Config
 

--- a/build-standard-locally.sh
+++ b/build-standard-locally.sh
@@ -3,5 +3,5 @@ rm -rf Config
 mkdir Config
 go run .
 cp -r Config-Shared/* Config
-cp -r Config-CrystalHell/* Config
+cp -r Config-Standard/* Config
 

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -72,8 +72,8 @@ func (p *Aloe) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedAloe2_%s"/>
 	<property name="Shape" value="ModelEntity"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Aloe) writeStage2(c chan string, traits string) {

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -88,7 +88,7 @@ func (*Aloe) writeStage2(c chan string, traits string) {
 
 func (p *Aloe) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedAloe3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedAloe1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropAloeLeaf" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropAloeLeaf" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -120,7 +120,6 @@ func (p *Aloe) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -61,63 +61,63 @@ func (p *Aloe) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Aloe) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedAloe1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedAloe1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedAloe1"/>
-	<property name="DescriptionKey" value="plantedAloe1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Model" value="Entities/Plants/plant_aloe1_Prefab"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedAloe2_%s"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedAloe1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedAloe1"/>
+    <property name="DescriptionKey" value="plantedAloe1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Model" value="Entities/Plants/plant_aloe1_Prefab"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedAloe2_%s"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Aloe) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedAloe2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedAloe1_%s"/>
-	<property name="DescriptionKey" value="plantedAloe2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="Entities/Plants/plant_aloe2_Prefab"/>
-	<property name="PlantGrowing.Next" value="plantedAloe3_%s"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedAloe1_%s"/>
+    <property name="DescriptionKey" value="plantedAloe2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="Entities/Plants/plant_aloe2_Prefab"/>
+    <property name="PlantGrowing.Next" value="plantedAloe3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Aloe) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedAloe3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropAloeLeaf" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropAloeLeaf" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedAloe1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedAloe3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="Group" value="Food/Cooking,Science"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Mesh" value="grass"/>
-	<property name="Model" value="Entities/Plants/plant_aloe_harvestPrefab"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropAloeLeaf" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropAloeLeaf" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedAloe1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedAloe3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="Group" value="Food/Cooking,Science"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Mesh" value="grass"/>
+    <property name="Model" value="Entities/Plants/plant_aloe_harvestPrefab"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -81,6 +81,8 @@ func (*Aloe) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedAloe1_%s"/>
+	<property name="DescriptionKey" value="plantedAloe2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="Entities/Plants/plant_aloe2_Prefab"/>
 	<property name="PlantGrowing.Next" value="plantedAloe3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -96,8 +96,8 @@ func (p *Aloe) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedAloe1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedAloe3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedAloe3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="Group" value="Food/Cooking,Science"/>
@@ -122,6 +122,5 @@ func (p *Aloe) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -95,8 +95,8 @@ func (p *Blueberry) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedBlueberry1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedBlueberry3_%s"/>
-	<property name="DisplayInfo" value="Name"/>
+	<property name="DescriptionKey" value="plantedBlueberry3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -120,6 +120,5 @@ func (p *Blueberry) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -80,6 +80,8 @@ func (*Blueberry) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedBlueberry1_%s"/>
+	<property name="DescriptionKey" value="plantedBlueberry2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="Entities/Plants/blueberry_plant_growthPrefab"/>
 	<property name="PlantGrowing.Next" value="plantedBlueberry3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -71,8 +71,8 @@ func (p *Blueberry) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedBlueberry2_%s"/>
 	<property name="Shape" value="ModelEntity"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Blueberry) writeStage2(c chan string, traits string) {

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -61,61 +61,61 @@ func (p *Blueberry) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Blueberry) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedBlueberry1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedBlueberry1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedBlueberry1"/>
-	<property name="DescriptionKey" value="plantedBlueberry1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Model" value="Entities/Plants/blueberry_plant_sproutPrefab"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedBlueberry2_%s"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedBlueberry1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedBlueberry1"/>
+    <property name="DescriptionKey" value="plantedBlueberry1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Model" value="Entities/Plants/blueberry_plant_sproutPrefab"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedBlueberry2_%s"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Blueberry) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedBlueberry2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedBlueberry1_%s"/>
-	<property name="DescriptionKey" value="plantedBlueberry2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="Entities/Plants/blueberry_plant_growthPrefab"/>
-	<property name="PlantGrowing.Next" value="plantedBlueberry3_%s"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedBlueberry1_%s"/>
+    <property name="DescriptionKey" value="plantedBlueberry2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="Entities/Plants/blueberry_plant_growthPrefab"/>
+    <property name="PlantGrowing.Next" value="plantedBlueberry3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Blueberry) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedBlueberry3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropBlueberries" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropBlueberries" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedBlueberry1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedBlueberry3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="Model" value="Entities/Plants/blueberry_plant_harvestPrefab"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropBlueberries" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropBlueberries" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedBlueberry1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedBlueberry3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="Model" value="Entities/Plants/blueberry_plant_harvestPrefab"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -87,7 +87,7 @@ func (*Blueberry) writeStage2(c chan string, traits string) {
 
 func (p *Blueberry) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedBlueberry3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedBlueberry1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropBlueberries" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropBlueberries" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -118,7 +118,6 @@ func (p *Blueberry) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -79,6 +79,8 @@ func (*Chrysanthemum) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedChrysanthemum1_%s"/>
+	<property name="DescriptionKey" value="plantedChrysanthemum2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedChrysanthemum3_%s"/>
 	<property name="Texture" value="551"/>
 </block>`, traits, traits, traits, traits)

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -86,7 +86,7 @@ func (*Chrysanthemum) writeStage2(c chan string, traits string) {
 
 func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedChrysanthemum3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedChrysanthemum1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropChrysanthemumPlant" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropChrysanthemumPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -115,7 +115,6 @@ func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -61,58 +61,58 @@ func (p *Chrysanthemum) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Chrysanthemum) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedChrysanthemum1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedChrysanthemum1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedChrysanthemum1"/>
-	<property name="DescriptionKey" value="plantedChrysanthemum1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedChrysanthemum2_%s"/>
-	<property name="Texture" value="550"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedChrysanthemum1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedChrysanthemum1"/>
+    <property name="DescriptionKey" value="plantedChrysanthemum1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedChrysanthemum2_%s"/>
+    <property name="Texture" value="550"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Chrysanthemum) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedChrysanthemum2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedChrysanthemum1_%s"/>
-	<property name="DescriptionKey" value="plantedChrysanthemum2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="PlantGrowing.Next" value="plantedChrysanthemum3_%s"/>
-	<property name="Texture" value="551"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedChrysanthemum1_%s"/>
+    <property name="DescriptionKey" value="plantedChrysanthemum2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="PlantGrowing.Next" value="plantedChrysanthemum3_%s"/>
+    <property name="Texture" value="551"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedChrysanthemum3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropChrysanthemumPlant" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropChrysanthemumPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedChrysanthemum1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedChrysanthemum3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="244"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropChrysanthemumPlant" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropChrysanthemumPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedChrysanthemum1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedChrysanthemum3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="244"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -94,8 +94,8 @@ func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedChrysanthemum1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedChrysanthemum3_%s"/>
-	<property name="DisplayInfo" value="Name"/>
+	<property name="DescriptionKey" value="plantedChrysanthemum3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_helpers,SC_helperOutdoor"/>
 	<property name="ImposterDontBlock" value="true"/>
@@ -117,6 +117,5 @@ func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -70,8 +70,8 @@ func (p *Chrysanthemum) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedChrysanthemum2_%s"/>
 	<property name="Texture" value="550"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Chrysanthemum) writeStage2(c chan string, traits string) {

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -95,8 +95,8 @@ func (p *Coffee) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedCoffee1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCoffee3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedCoffee3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -119,6 +119,5 @@ func (p *Coffee) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -87,7 +87,7 @@ func (*Coffee) writeStage2(c chan string, traits string) {
 
 func (p *Coffee) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCoffee3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedCoffee1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropCoffeeBeans" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropCoffeeBeans" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -117,7 +117,6 @@ func (p *Coffee) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -61,60 +61,60 @@ func (p *Coffee) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Coffee) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCoffee1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedCoffee1_%s" count="1"/>
-	<property name="CraftingIngredientTime" value="5"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedCoffee1"/>
-	<property name="DescriptionKey" value="plantedCoffee1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedCoffee2_%s"/>
-	<property name="Texture" value="393"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedCoffee1_%s" count="1"/>
+    <property name="CraftingIngredientTime" value="5"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedCoffee1"/>
+    <property name="DescriptionKey" value="plantedCoffee1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedCoffee2_%s"/>
+    <property name="Texture" value="393"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Coffee) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCoffee2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedCoffee1_%s"/>
-	<property name="DescriptionKey" value="plantedCoffee2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="PlantGrowing.Next" value="plantedCoffee3_%s"/>
-	<property name="Texture" value="394"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedCoffee1_%s"/>
+    <property name="DescriptionKey" value="plantedCoffee2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="PlantGrowing.Next" value="plantedCoffee3_%s"/>
+    <property name="Texture" value="394"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Coffee) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCoffee3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropCoffeeBeans" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropCoffeeBeans" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedCoffee1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCoffee3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropCoffeeBeans" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropCoffeeBeans" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedCoffee1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedCoffee3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -80,6 +80,8 @@ func (*Coffee) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedCoffee1_%s"/>
+	<property name="DescriptionKey" value="plantedCoffee2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedCoffee3_%s"/>
 	<property name="Texture" value="394"/>
 </block>`, traits, traits, traits, traits)

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -71,8 +71,8 @@ func (p *Coffee) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedCoffee2_%s"/>
 	<property name="Texture" value="393"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Coffee) writeStage2(c chan string, traits string) {

--- a/data/corn.go
+++ b/data/corn.go
@@ -63,67 +63,67 @@ func (p *Corn) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Corn) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCorn1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedCorn1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedCorn1"/>
-	<property name="DescriptionKey" value="plantedCorn1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Material" value="Mcorn"/> <!-- mostly for the particle effect -->
-	<property name="Mesh" value="cutoutmoveable"/>
-	<property name="Model" value="corn_sprout_shape"/>
-	<property name="MultiBlockDim" value="1,3,1"/>
-	<property name="Place" value="Door"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedCorn2_%s"/>
-	<property name="Shape" value="New"/>
-	<property name="Texture" value="529"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedCorn1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="DescriptionKey" value="plantedCorn1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Material" value="Mcorn"/> <!-- mostly for the particle effect -->
+    <property name="Mesh" value="cutoutmoveable"/>
+    <property name="Model" value="corn_sprout_shape"/>
+    <property name="MultiBlockDim" value="1,3,1"/>
+    <property name="Place" value="Door"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedCorn2_%s"/>
+    <property name="Shape" value="New"/>
+    <property name="Texture" value="529"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Corn) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCorn2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedCorn1_%s"/>
-	<property name="DescriptionKey" value="plantedCorn2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="corn_growth_shape"/>
-	<property name="PlantGrowing.Next" value="plantedCorn3_%s"/>
-	<property name="Texture" value="529"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedCorn1_%s"/>
+    <property name="DescriptionKey" value="plantedCorn2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="corn_growth_shape"/>
+    <property name="PlantGrowing.Next" value="plantedCorn3_%s"/>
+    <property name="Texture" value="529"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Corn) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCorn3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropCorn" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedCorn1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCorn3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Mesh" value="cutoutmoveable"/>
-	<property name="Model" value="corn_harvest_shape"/>
-	<property name="MultiBlockDim" value="1,3,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="New"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="529"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropCorn" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedCorn3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Mesh" value="cutoutmoveable"/>
+    <property name="Model" value="corn_harvest_shape"/>
+    <property name="MultiBlockDim" value="1,3,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="New"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="529"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/corn.go
+++ b/data/corn.go
@@ -95,7 +95,7 @@ func (*Corn) writeStage2(c chan string, traits string) {
 
 func (p *Corn) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCorn3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedCorn1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropCorn" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -125,7 +125,6 @@ func (p *Corn) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/corn.go
+++ b/data/corn.go
@@ -78,8 +78,8 @@ func (p *Corn) writeStage1(c chan string, target, traits string) {
 	<property name="PlantGrowing.Next" value="plantedCorn2_%s"/>
 	<property name="Shape" value="New"/>
 	<property name="Texture" value="529"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Corn) writeStage2(c chan string, traits string) {

--- a/data/corn.go
+++ b/data/corn.go
@@ -87,6 +87,8 @@ func (*Corn) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedCorn1_%s"/>
+	<property name="DescriptionKey" value="plantedCorn2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="corn_growth_shape"/>
 	<property name="PlantGrowing.Next" value="plantedCorn3_%s"/>
 	<property name="Texture" value="529"/>

--- a/data/corn.go
+++ b/data/corn.go
@@ -103,7 +103,8 @@ func (p *Corn) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedCorn1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCorn3_%s"/>
+	<property name="DescriptionKey" value="plantedCorn3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -127,6 +128,5 @@ func (p *Corn) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -94,8 +94,8 @@ func (p *Cotton) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedCotton1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCotton3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedCotton3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -118,6 +118,5 @@ func (p *Cotton) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -61,59 +61,59 @@ func (p *Cotton) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Cotton) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCotton1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedCotton1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedCotton1"/>
-	<property name="DescriptionKey" value="plantedCotton1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedCotton2_%s"/>
-	<property name="Texture" value="392"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedCotton1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedCotton1"/>
+    <property name="DescriptionKey" value="plantedCotton1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedCotton2_%s"/>
+    <property name="Texture" value="392"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Cotton) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCotton2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedCotton1_%s"/>
-	<property name="DescriptionKey" value="plantedCotton2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="PlantGrowing.Next" value="plantedCotton3_%s"/>
-	<property name="Texture" value="20"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedCotton1_%s"/>
+    <property name="DescriptionKey" value="plantedCotton2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="PlantGrowing.Next" value="plantedCotton3_%s"/>
+    <property name="Texture" value="20"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Cotton) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCotton3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropCottonPlant" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropCottonPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedCotton1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedCotton3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="363"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropCottonPlant" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropCottonPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedCotton1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedCotton3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="363"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -70,8 +70,8 @@ func (p *Cotton) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedCotton2_%s"/>
 	<property name="Texture" value="392"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Cotton) writeStage2(c chan string, traits string) {

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -86,7 +86,7 @@ func (*Cotton) writeStage2(c chan string, traits string) {
 
 func (p *Cotton) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedCotton3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedCotton1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropCottonPlant" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropCottonPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -116,7 +116,6 @@ func (p *Cotton) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -79,6 +79,8 @@ func (*Cotton) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedCotton1_%s"/>
+	<property name="DescriptionKey" value="plantedCotton2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedCotton3_%s"/>
 	<property name="Texture" value="20"/>
 </block>`, traits, traits, traits, traits)

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -94,8 +94,8 @@ func (p *Goldenrod) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedGoldenrod1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedGoldenrod3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedGoldenrod3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -118,6 +118,5 @@ func (p *Goldenrod) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -86,7 +86,7 @@ func (*Goldenrod) writeStage2(c chan string, traits string) {
 
 func (p *Goldenrod) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGoldenrod3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedGoldenrod1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropGoldenrodPlant" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropGoldenrodPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -116,7 +116,6 @@ func (p *Goldenrod) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -79,6 +79,8 @@ func (*Goldenrod) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedGoldenrod1_%s"/>
+	<property name="DescriptionKey" value="plantedGoldenrod2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedGoldenrod3_%s"/>
 	<property name="Texture" value="402"/>
 </block>`, traits, traits, traits, traits)

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -70,8 +70,8 @@ func (p *Goldenrod) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedGoldenrod2_%s"/>
 	<property name="Texture" value="401"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Goldenrod) writeStage2(c chan string, traits string) {

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -61,59 +61,59 @@ func (p *Goldenrod) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Goldenrod) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGoldenrod1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedGoldenrod1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedGoldenrod1"/>
-	<property name="DescriptionKey" value="plantedGoldenrod1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster"/>
-	<property name="Group" value="%s"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedGoldenrod2_%s"/>
-	<property name="Texture" value="401"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedGoldenrod1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedGoldenrod1"/>
+    <property name="DescriptionKey" value="plantedGoldenrod1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster"/>
+    <property name="Group" value="%s"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedGoldenrod2_%s"/>
+    <property name="Texture" value="401"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Goldenrod) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGoldenrod2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedGoldenrod1_%s"/>
-	<property name="DescriptionKey" value="plantedGoldenrod2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="PlantGrowing.Next" value="plantedGoldenrod3_%s"/>
-	<property name="Texture" value="402"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedGoldenrod1_%s"/>
+    <property name="DescriptionKey" value="plantedGoldenrod2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="PlantGrowing.Next" value="plantedGoldenrod3_%s"/>
+    <property name="Texture" value="402"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Goldenrod) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGoldenrod3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropGoldenrodPlant" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropGoldenrodPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedGoldenrod1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedGoldenrod3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="362"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropGoldenrodPlant" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropGoldenrodPlant" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedGoldenrod1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedGoldenrod3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="362"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -100,8 +100,8 @@ func (p *GraceCorn) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedCorn1"/>
 	<property name="CustomIconTint" value="ff8f9f"/>
-	<property name="DescriptionKey" value="plantedGraceCorn3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedGraceCorn3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -125,6 +125,5 @@ func (p *GraceCorn) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -61,68 +61,68 @@ func (p *GraceCorn) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *GraceCorn) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGraceCorn1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedGraceCorn1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedCorn1"/>
-	<property name="CustomIconTint" value="ff9f9f"/>
-	<property name="DescriptionKey" value="plantedGraceCorn1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Material" value="Mcorn"/> <!-- mostly for the particle effect -->
-	<property name="Mesh" value="cutoutmoveable"/>
-	<property name="Model" value="corn_sprout_shape"/>
-	<property name="MultiBlockDim" value="1,3,1"/>
-	<property name="Place" value="Door"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedGraceCorn2_%s"/>
-	<property name="Shape" value="New"/>
-	<property name="Texture" value="529"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedGraceCorn1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="CustomIconTint" value="ff9f9f"/>
+    <property name="DescriptionKey" value="plantedGraceCorn1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Material" value="Mcorn"/> <!-- mostly for the particle effect -->
+    <property name="Mesh" value="cutoutmoveable"/>
+    <property name="Model" value="corn_sprout_shape"/>
+    <property name="MultiBlockDim" value="1,3,1"/>
+    <property name="Place" value="Door"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedGraceCorn2_%s"/>
+    <property name="Shape" value="New"/>
+    <property name="Texture" value="529"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*GraceCorn) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGraceCorn2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff9f"/>
-	<property name="Extends" value="plantedGraceCorn1_%s"/>
-	<property name="DescriptionKey" value="plantedGraceCorn2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="corn_growth_shape"/>
-	<property name="PlantGrowing.Next" value="plantedGraceCorn3_%s"/>
-	<property name="Texture" value="529"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff9f"/>
+    <property name="Extends" value="plantedGraceCorn1_%s"/>
+    <property name="DescriptionKey" value="plantedGraceCorn2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="corn_growth_shape"/>
+    <property name="PlantGrowing.Next" value="plantedGraceCorn3_%s"/>
+    <property name="Texture" value="529"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *GraceCorn) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGraceCorn3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropGraceCorn" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropGraceCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedCorn1"/>
-	<property name="CustomIconTint" value="ff8f9f"/>
-	<property name="DescriptionKey" value="plantedGraceCorn3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Mesh" value="cutoutmoveable"/>
-	<property name="Model" value="corn_harvest_shape"/>
-	<property name="MultiBlockDim" value="1,3,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="New"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="529"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropGraceCorn" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropGraceCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="CustomIconTint" value="ff8f9f"/>
+    <property name="DescriptionKey" value="plantedGraceCorn3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Mesh" value="cutoutmoveable"/>
+    <property name="Model" value="corn_harvest_shape"/>
+    <property name="MultiBlockDim" value="1,3,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="New"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="529"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -92,7 +92,7 @@ func (*GraceCorn) writeStage2(c chan string, traits string) {
 
 func (p *GraceCorn) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedGraceCorn3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedGraceCorn1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropGraceCorn" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropGraceCorn" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -123,7 +123,6 @@ func (p *GraceCorn) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -86,6 +86,8 @@ func (*GraceCorn) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff9f"/>
 	<property name="Extends" value="plantedGraceCorn1_%s"/>
+	<property name="DescriptionKey" value="plantedGraceCorn2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedGraceCorn3_%s"/>
 </block>`, traits, traits, traits, traits)
 }

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -77,8 +77,8 @@ func (p *GraceCorn) writeStage1(c chan string, target, traits string) {
 	<property name="PlantGrowing.Next" value="plantedGraceCorn2_%s"/>
 	<property name="Shape" value="New"/>
 	<property name="Texture" value="529"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*GraceCorn) writeStage2(c chan string, traits string) {

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -88,7 +88,9 @@ func (*GraceCorn) writeStage2(c chan string, traits string) {
 	<property name="Extends" value="plantedGraceCorn1_%s"/>
 	<property name="DescriptionKey" value="plantedGraceCorn2"/>
 	<property name="DisplayInfo" value="Description"/>
+	<property name="Model" value="corn_growth_shape"/>
 	<property name="PlantGrowing.Next" value="plantedGraceCorn3_%s"/>
+	<property name="Texture" value="529"/>
 </block>`, traits, traits, traits, traits)
 }
 

--- a/data/hop.go
+++ b/data/hop.go
@@ -94,8 +94,8 @@ func (p *Hop) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedHop1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedHop3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedHop3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -119,6 +119,5 @@ func (p *Hop) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/hop.go
+++ b/data/hop.go
@@ -61,60 +61,60 @@ func (p *Hop) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Hop) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedHop1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedHop1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedHop1"/>
-	<property name="DescriptionKey" value="plantedHop1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedHop2_%s"/>
-	<property name="Texture" value="447"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedHop1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedHop1"/>
+    <property name="DescriptionKey" value="plantedHop1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedHop2_%s"/>
+    <property name="Texture" value="447"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Hop) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedHop2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedHop1_%s"/>
-	<property name="DescriptionKey" value="plantedHop2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="PlantGrowing.Next" value="plantedHop3_%s"/>
-	<property name="Texture" value="448"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedHop1_%s"/>
+    <property name="DescriptionKey" value="plantedHop2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="PlantGrowing.Next" value="plantedHop3_%s"/>
+    <property name="Texture" value="448"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Hop) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedHop3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="resourceCropHopsFlower" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="resourceCropHopsFlower" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedHop1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedHop3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	<property name="Texture" value="449"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="resourceCropHopsFlower" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="resourceCropHopsFlower" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedHop1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedHop3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    <property name="Texture" value="449"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/hop.go
+++ b/data/hop.go
@@ -70,8 +70,8 @@ func (p *Hop) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedHop2_%s"/>
 	<property name="Texture" value="447"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Hop) writeStage2(c chan string, traits string) {

--- a/data/hop.go
+++ b/data/hop.go
@@ -86,7 +86,7 @@ func (*Hop) writeStage2(c chan string, traits string) {
 
 func (p *Hop) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedHop3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedHop1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="resourceCropHopsFlower" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="resourceCropHopsFlower" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -117,7 +117,6 @@ func (p *Hop) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/hop.go
+++ b/data/hop.go
@@ -79,6 +79,8 @@ func (*Hop) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedHop1_%s"/>
+	<property name="DescriptionKey" value="plantedHop2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="PlantGrowing.Next" value="plantedHop3_%s"/>
 	<property name="Texture" value="448"/>
 </block>`, traits, traits, traits, traits)

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -103,7 +103,7 @@ func (*Mushroom) writeStage2(c chan string, traits string) {
 
 func (p *Mushroom) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedMushroom3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedMushroom1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropMushrooms" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropMushrooms" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -130,7 +130,6 @@ func (p *Mushroom) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -86,8 +86,8 @@ func (p *Mushroom) writeStage1(c chan string, target, traits string) {
 	<property name="PlantGrowing.Next" value="plantedMushroom2_%s"/>
 	<property name="Shape" value="Ext3dModel"/>
 	<property name="Texture" value="293"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Mushroom) writeStage2(c chan string, traits string) {

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -112,7 +112,8 @@ func (p *Mushroom) writeStage3(c chan string, traits string) {
 	<property name="CropsGrown.BonusHarvestDivisor" value="16"/>
 	<property name="CustomIcon" value="plantedMushroom1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedMushroom3_%s"/>
+	<property name="DescriptionKey" value="plantedMushroom3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -132,6 +133,5 @@ func (p *Mushroom) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -63,72 +63,72 @@ func (p *Mushroom) WriteBlockStages(c chan string, target, traits string) {
 // TODO: return to mushroom... seems like overkill - why not extend naturally?
 func (p *Mushroom) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedMushroom1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedMushroom1_%s" count="1"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedMushroom1"/>
-	<property name="DescriptionKey" value="plantedMushroom1_%sDesc"/>
-	<property name="DisplayInfo" value="Name"/>
-	<property name="EconomicBundleSize" value="5"/>
-	<property name="EconomicValue" value="12"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon,DescriptionKey,MultiBlockDim,OnlySimpleRotations"/>
-	<property name="Group" value="%s"/>
-	<property name="HandleFace" value="Bottom"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mmushrooms"/>
-	<property name="Mesh" value="models"/>
-	<property name="Model" value="OutdoorDecor/mushroom_sprout" param1="main_mesh"/>
-	<property name="PickupJournalEntry" value="farmingTip"/>
-	<property name="PlantGrowing.FertileLevel" value="0"/>
-	<property name="PlantGrowing.LightLevelGrow" value="0"/>
-	<property name="PlantGrowing.LightLevelStay" value="0"/>
-	<property name="PlantGrowing.Next" value="plantedMushroom2_%s"/>
-	<property name="Shape" value="Ext3dModel"/>
-	<property name="Texture" value="293"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedMushroom1_%s" count="1"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedMushroom1"/>
+    <property name="DescriptionKey" value="plantedMushroom1_%sDesc"/>
+    <property name="DisplayInfo" value="Name"/>
+    <property name="EconomicBundleSize" value="5"/>
+    <property name="EconomicValue" value="12"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon,DescriptionKey,MultiBlockDim,OnlySimpleRotations"/>
+    <property name="Group" value="%s"/>
+    <property name="HandleFace" value="Bottom"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mmushrooms"/>
+    <property name="Mesh" value="models"/>
+    <property name="Model" value="OutdoorDecor/mushroom_sprout" param1="main_mesh"/>
+    <property name="PickupJournalEntry" value="farmingTip"/>
+    <property name="PlantGrowing.FertileLevel" value="0"/>
+    <property name="PlantGrowing.LightLevelGrow" value="0"/>
+    <property name="PlantGrowing.LightLevelStay" value="0"/>
+    <property name="PlantGrowing.Next" value="plantedMushroom2_%s"/>
+    <property name="Shape" value="Ext3dModel"/>
+    <property name="Texture" value="293"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Mushroom) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedMushroom2_%s" stage="2" traits="%s">
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedMushroom1_%s"/>
-	<property name="DescriptionKey" value="plantedMushroom2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="OutdoorDecor/mushroom_growth" param1="main_mesh"/>
-	<property name="PlantGrowing.Next" value="plantedMushroom3_%s"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedMushroom1_%s"/>
+    <property name="DescriptionKey" value="plantedMushroom2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="OutdoorDecor/mushroom_growth" param1="main_mesh"/>
+    <property name="PlantGrowing.Next" value="plantedMushroom3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Mushroom) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedMushroom3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropMushrooms" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropMushrooms" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CropsGrown.BonusHarvestDivisor" value="16"/>
-	<property name="CustomIcon" value="plantedMushroom1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedMushroom3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="Material" value="Mmushrooms"/>
-	<property name="Mesh" value="models"/>
-	<property name="Model" value="OutdoorDecor/mushroom_harvest" param1="main_mesh"/>
-	<property name="PickupJournalEntry" value="farmingTip"/>
-	<property name="PlantGrowing.FertileLevel" value="0"/>
-	<property name="Shape" value="Ext3dModel"/>
-	<property name="Texture" value="293"/>
-	<property name="VehicleHitScale" value=".1"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropMushrooms" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropMushrooms" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CropsGrown.BonusHarvestDivisor" value="16"/>
+    <property name="CustomIcon" value="plantedMushroom1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedMushroom3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="Material" value="Mmushrooms"/>
+    <property name="Mesh" value="models"/>
+    <property name="Model" value="OutdoorDecor/mushroom_harvest" param1="main_mesh"/>
+    <property name="PickupJournalEntry" value="farmingTip"/>
+    <property name="PlantGrowing.FertileLevel" value="0"/>
+    <property name="Shape" value="Ext3dModel"/>
+    <property name="Texture" value="293"/>
+    <property name="VehicleHitScale" value=".1"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -96,6 +96,8 @@ func (*Mushroom) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedMushroom1_%s"/>
+	<property name="DescriptionKey" value="plantedMushroom2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="OutdoorDecor/mushroom_growth" param1="main_mesh"/>
 	<property name="PlantGrowing.Next" value="plantedMushroom3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/data/plant.go
+++ b/data/plant.go
@@ -115,14 +115,14 @@ var Plants []Plant = []Plant{
 
 func calculateCropYield(count int, traits string) int {
 
-	// All Enhanced Seeds start wtih double resources
+	// All Enhanced Seeds start with double resources
 	count *= 2
 
 	// [B] Bonus
 	if strings.Contains(traits, "BB") {
 		count *= 4
 	} else if strings.Contains(traits, "B") {
-		count = int(float64(count) * 2)
+		count *= 2
 	}
 
 	return count

--- a/data/plant.go
+++ b/data/plant.go
@@ -147,7 +147,7 @@ func optionallyAddRenewable(traits string, plant Plant) string {
 
 func optionallyAddUnlock(plant Plant, target, traits string) string {
 	switch target {
-	case "Vanilla":
+	case "Researcher":
 		return fmt.Sprintf(`<property name="UnlockedBy" value="%s"/>`, plant.GetSchematicName(traits))
 	default:
 		return ""

--- a/data/plant.go
+++ b/data/plant.go
@@ -155,7 +155,7 @@ func getUnlock(plant Plant, target, traits string) string {
 }
 
 func getDefaultSeedDescription() string {
-	return `Plant these seeds on a craftable Farm Plot block to grow plants for you to harvest.\n\nWhen harvested, there is a 50% chance to get a seed back for replanting.`
+	return `Plant these seeds on a craftable Farm Plot block to grow plants for you to harvest.`
 }
 
 func getCraftingGroup(traits string) string {

--- a/data/plant.go
+++ b/data/plant.go
@@ -145,12 +145,12 @@ func optionallyAddRenewable(traits string, plant Plant) string {
 	return ""
 }
 
-func optionallyAddUnlock(plant Plant, target, traits string) string {
+func getUnlock(plant Plant, target, traits string) string {
 	switch target {
 	case "Researcher":
-		return fmt.Sprintf(`<property name="UnlockedBy" value="%s"/>`, plant.GetSchematicName(traits))
+		return plant.GetSchematicName(traits)
 	default:
-		return ""
+		return "perkLivingOffTheLand"
 	}
 }
 

--- a/data/potato.go
+++ b/data/potato.go
@@ -87,7 +87,7 @@ func (*Potato) writeStage2(c chan string, traits string) {
 
 func (p *Potato) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPotato3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedPotato1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropPotato" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropPotato" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -119,7 +119,6 @@ func (p *Potato) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/potato.go
+++ b/data/potato.go
@@ -61,62 +61,62 @@ func (p *Potato) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Potato) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPotato1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedPotato1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedPotato1"/>
-	<property name="DescriptionKey" value="plantedPotato1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Model" value="Entities/Plants/potato_plant_sproutPrefab"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedPotato2_%s"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedPotato1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedPotato1"/>
+    <property name="DescriptionKey" value="plantedPotato1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Model" value="Entities/Plants/potato_plant_sproutPrefab"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedPotato2_%s"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Potato) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPotato2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedPotato1_%s"/>
-	<property name="DescriptionKey" value="plantedPotato2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="Entities/Plants/potato_plant_growthPrefab"/>
-	<property name="PlantGrowing.Next" value="plantedPotato3_%s"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedPotato1_%s"/>
+    <property name="DescriptionKey" value="plantedPotato2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="Entities/Plants/potato_plant_growthPrefab"/>
+    <property name="PlantGrowing.Next" value="plantedPotato3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Potato) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPotato3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropPotato" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropPotato" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedPotato1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedPotato3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="Extends" value="cropsHarvestableMaster"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="Model" value="Entities/Plants/potato_plant_harvestPrefab"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropPotato" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropPotato" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedPotato1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedPotato3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="Extends" value="cropsHarvestableMaster"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="Model" value="Entities/Plants/potato_plant_harvestPrefab"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/potato.go
+++ b/data/potato.go
@@ -95,7 +95,7 @@ func (p *Potato) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedPotato1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedPotato3_%sDesc"/>
+	<property name="DescriptionKey" value="plantedPotato3_%s"/>
 	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="Extends" value="cropsHarvestableMaster"/>

--- a/data/potato.go
+++ b/data/potato.go
@@ -71,8 +71,8 @@ func (p *Potato) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedPotato2_%s"/>
 	<property name="Shape" value="ModelEntity"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Potato) writeStage2(c chan string, traits string) {

--- a/data/potato.go
+++ b/data/potato.go
@@ -80,6 +80,8 @@ func (*Potato) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedPotato1_%s"/>
+	<property name="DescriptionKey" value="plantedPotato2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="Entities/Plants/potato_plant_growthPrefab"/>
 	<property name="PlantGrowing.Next" value="plantedPotato3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/data/potato.go
+++ b/data/potato.go
@@ -95,8 +95,8 @@ func (p *Potato) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedPotato1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedPotato3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedPotato3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="Extends" value="cropsHarvestableMaster"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
@@ -121,6 +121,5 @@ func (p *Potato) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -61,65 +61,65 @@ func (p *Pumpkin) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Pumpkin) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPumpkin1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedPumpkin1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedPumpkin1"/>
-	<property name="DescriptionKey" value="plantedPumpkin1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Model" value="Entities/Plants/pumpkinSproutPrefab"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedPumpkin2_%s"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedPumpkin1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedPumpkin1"/>
+    <property name="DescriptionKey" value="plantedPumpkin1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Model" value="Entities/Plants/pumpkinSproutPrefab"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedPumpkin2_%s"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Pumpkin) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPumpkin2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedPumpkin1_%s"/>
-	<property name="DescriptionKey" value="plantedPumpkin2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="Entities/Plants/pumpkinGrowthPrefab"/>
-	<property name="PlantGrowing.Next" value="plantedPumpkin3_%s"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedPumpkin1_%s"/>
+    <property name="DescriptionKey" value="plantedPumpkin2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="Entities/Plants/pumpkinGrowthPrefab"/>
+    <property name="PlantGrowing.Next" value="plantedPumpkin3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Pumpkin) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPumpkin3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropPumpkin" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropPumpkin" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedPumpkin1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedPumpkin3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="Extends" value="cropsHarvestableMaster"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Material" value="Mplants"/>
-	<property name="Mesh" value="grass"/>
-	<property name="Model" value="Entities/Plants/pumpkinHarvestPrefab"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="BillboardPlant"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropPumpkin" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropPumpkin" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedPumpkin1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedPumpkin3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="Extends" value="cropsHarvestableMaster"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Material" value="Mplants"/>
+    <property name="Mesh" value="grass"/>
+    <property name="Model" value="Entities/Plants/pumpkinHarvestPrefab"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="BillboardPlant"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -88,7 +88,7 @@ func (*Pumpkin) writeStage2(c chan string, traits string) {
 
 func (p *Pumpkin) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedPumpkin3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedPumpkin1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropPumpkin" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropPumpkin" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -122,7 +122,6 @@ func (p *Pumpkin) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -72,8 +72,8 @@ func (p *Pumpkin) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedPumpkin2_%s"/>
 	<property name="Shape" value="ModelEntity"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Pumpkin) writeStage2(c chan string, traits string) {

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -96,8 +96,8 @@ func (p *Pumpkin) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedPumpkin1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedPumpkin3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedPumpkin3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="Extends" value="cropsHarvestableMaster"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
@@ -124,6 +124,5 @@ func (p *Pumpkin) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -81,6 +81,8 @@ func (*Pumpkin) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedPumpkin1_%s"/>
+	<property name="DescriptionKey" value="plantedPumpkin2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="Entities/Plants/pumpkinGrowthPrefab"/>
 	<property name="PlantGrowing.Next" value="plantedPumpkin3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/data/trait.go
+++ b/data/trait.go
@@ -69,7 +69,7 @@ func (t *Trait) GetDoubleTraitDescription() string {
 		return fmt.Sprintf(`%s: triggers a concealed explosive with a large payload when stepped on, struck with a melee weapon, or hit with an arrow.\n- Due to the flexible nature of plants, the detonator will not trigger if struck with bullets or other explosives.`,
 			t.DoubleName)
 	case 'T':
-		return fmt.Sprintf(`%s: integrates with many sharp, metal thorns. Touching them will cause one to receive damage and bleed.`,
+		return fmt.Sprintf(`%s: integrates with many sharp, metal thorns. Touching them will cause one to bleed profusely.`,
 			t.DoubleName)
 	}
 	return ""

--- a/data/trait.go
+++ b/data/trait.go
@@ -32,7 +32,7 @@ var Traits []Trait = []Trait{
 	{Code: 'F', Name: "Fast Growth", DoubleName: "Rapid Growth", Ingredients: []Ingredient{
 		{"drinkCanMegaCrush", 2},
 	}},
-	{Code: 'E', Name: "Explosive", DoubleName: "Extremely Explosive", IncompatibleTraits: []rune{'B', 'R'}, Ingredients: []Ingredient{
+	{Code: 'E', Name: "Explosive", DoubleName: "Extremely Explosive", IncompatibleTraits: []rune{'B', 'R', 'T'}, Ingredients: []Ingredient{
 		{"resourceScrapIron", 4},
 		{"resourceGunPowder", 4},
 		{"resourceDuctTape", 1},
@@ -40,7 +40,7 @@ var Traits []Trait = []Trait{
 	{Code: 'R', Name: "Renewable", IncompatibleTraits: []rune{'R', 'E'}, Ingredients: []Ingredient{
 		{"drinkJarPureMineralWater", 10},
 	}},
-	{Code: 'T', Name: "Thorny", DoubleName: "Extra Thorny", Ingredients: []Ingredient{
+	{Code: 'T', Name: "Thorny", DoubleName: "Extra Thorny", IncompatibleTraits: []rune{'E'}, Ingredients: []Ingredient{
 		{"resourceScrapIron", 10},
 		{"resourceNail", 10},
 	}},
@@ -82,7 +82,7 @@ func (t *Trait) GetTraitDescription() string {
 		return fmt.Sprintf(`%s: further doubles crop yield.`,
 			t.Name)
 	case 'U':
-		return fmt.Sprintf(`%s: fused with mushroom dna, alowing growth without the need for sunlight.`,
+		return fmt.Sprintf(`%s: fused with mushroom dna, allowing growth without the need for sunlight.`,
 			t.Name)
 	case 'F':
 		return fmt.Sprintf(`%s: reaches maturity in half the time.`,

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -88,7 +88,7 @@ func (*Yucca) writeStage2(c chan string, traits string) {
 
 func (p *Yucca) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedYucca3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" name="plantedYucca1_%s" count="1" prob="0.5"/>
+	<drop event="Destroy" count="0" />
 	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
 	<drop event="Harvest" name="foodCropYuccaFruit" count="%d" tag="cropHarvest"/>
 	<drop event="Harvest" name="foodCropYuccaFruit" prob="0.5" count="%d" tag="bonusCropHarvest"/>
@@ -119,7 +119,6 @@ func (p *Yucca) writeStage3(c chan string, traits string) {
 		traits,
 		traits,
 		calculatePlantTier(traits),
-		traits,
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
 		traits,

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -96,8 +96,8 @@ func (p *Yucca) writeStage3(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIcon" value="plantedYucca1"/>
 	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedYucca3_%s"/>
-	<property name="DisplayInfo" value="Description"/> <!-- also valid: "Name" -->
+	<property name="DescriptionKey" value="plantedYucca3HarvestDesc"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="DisplayType" value="blockMulti"/>
 	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
 	<property name="HarvestOverdamage" value="false"/>
@@ -121,6 +121,5 @@ func (p *Yucca) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
-		traits,
 		optionallyAddRenewable(traits, p))
 }

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -72,8 +72,8 @@ func (p *Yucca) writeStage1(c chan string, target, traits string) {
 	<property name="PlaceAsRandomRotation" value="true"/>
 	<property name="PlantGrowing.Next" value="plantedYucca2_%s"/>
 	<property name="Shape" value="ModelEntity"/>
-	%s
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, optionallyAddUnlock(p, target, traits))
+	<property name="UnlockedBy" value="%s"/>
+</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Yucca) writeStage2(c chan string, traits string) {

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -61,62 +61,62 @@ func (p *Yucca) WriteBlockStages(c chan string, target, traits string) {
 
 func (p *Yucca) writeStage1(c chan string, target, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedYucca1_%s" stage="1" traits="%s">
-	<drop event="Destroy" name="plantedYucca1_%s" count="1"/>
-	<property name="CreativeMode" value="Player"/>
-	<property name="CustomIcon" value="plantedYucca1"/>
-	<property name="DescriptionKey" value="plantedYucca1_%sDesc"/>
-	<property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
-	<property name="Group" value="%s"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Model" value="Entities/Plants/plant_yucca_sproutPrefab"/>
-	<property name="PlaceAsRandomRotation" value="true"/>
-	<property name="PlantGrowing.Next" value="plantedYucca2_%s"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="UnlockedBy" value="%s"/>
+    <drop event="Destroy" name="plantedYucca1_%s" count="1"/>
+    <property name="CreativeMode" value="Player"/>
+    <property name="CustomIcon" value="plantedYucca1"/>
+    <property name="DescriptionKey" value="plantedYucca1_%sDesc"/>
+    <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
+    <property name="Group" value="%s"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Model" value="Entities/Plants/plant_yucca_sproutPrefab"/>
+    <property name="PlaceAsRandomRotation" value="true"/>
+    <property name="PlantGrowing.Next" value="plantedYucca2_%s"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="UnlockedBy" value="%s"/>
 </block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Yucca) writeStage2(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedYucca2_%s" stage="2" traits="%s">
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIconTint" value="00ff80"/>
-	<property name="Extends" value="plantedYucca1_%s"/>
-	<property name="DescriptionKey" value="plantedYucca2"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="Model" value="Entities/Plants/plant_yucca_growthPrefab"/>
-	<property name="PlantGrowing.Next" value="plantedYucca3_%s"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIconTint" value="00ff80"/>
+    <property name="Extends" value="plantedYucca1_%s"/>
+    <property name="DescriptionKey" value="plantedYucca2"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="Model" value="Entities/Plants/plant_yucca_growthPrefab"/>
+    <property name="PlantGrowing.Next" value="plantedYucca3_%s"/>
 </block>`, traits, traits, traits, traits)
 }
 
 func (p *Yucca) writeStage3(c chan string, traits string) {
 	c <- fmt.Sprintf(`<block name="plantedYucca3_%s" stage="3" traits="%s" tags="T%dPlant">
-	<drop event="Destroy" count="0" />
-	<drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
-	<drop event="Harvest" name="foodCropYuccaFruit" count="%d" tag="cropHarvest"/>
-	<drop event="Harvest" name="foodCropYuccaFruit" prob="0.5" count="%d" tag="bonusCropHarvest"/>
-	<property name="Collide" value="melee"/>
-	<property name="CreativeMode" value="Dev"/>
-	<property name="CustomIcon" value="plantedYucca1"/>
-	<property name="CustomIconTint" value="ff8000"/>
-	<property name="DescriptionKey" value="plantedYucca3HarvestDesc"/>
-	<property name="DisplayInfo" value="Description"/>
-	<property name="DisplayType" value="blockMulti"/>
-	<property name="FilterTags" value="MC_outdoor,SC_crops"/>
-	<property name="HarvestOverdamage" value="false"/>
-	<property name="ImposterDontBlock" value="true"/>
-	<property name="IsDecoration" value="true"/>
-	<property name="IsTerrainDecoration" value="true"/>
-	<property name="LightOpacity" value="0"/>
-	<property name="Material" value="Mcorn"/>
-	<property name="Mesh" value="grass"/>
-	<property name="Model" value="Entities/Plants/plant_yucca_harvestPrefab"/>
-	<property name="MultiBlockDim" value="1,2,1"/>
-	<property name="PlantGrowing.FertileLevel" value="1"/>
-	<property name="Shape" value="ModelEntity"/>
-	<property name="SortOrder1" value="a090"/>
-	<property name="SortOrder2" value="0002"/>
-	<property name="Texture" value="395"/>
-	%s
+    <drop event="Destroy" count="0" />
+    <drop event="Fall" name="resourceYuccaFibers" count="0" prob="1" stick_chance="0"/>
+    <drop event="Harvest" name="foodCropYuccaFruit" count="%d" tag="cropHarvest"/>
+    <drop event="Harvest" name="foodCropYuccaFruit" prob="0.5" count="%d" tag="bonusCropHarvest"/>
+    <property name="Collide" value="melee"/>
+    <property name="CreativeMode" value="Dev"/>
+    <property name="CustomIcon" value="plantedYucca1"/>
+    <property name="CustomIconTint" value="ff8000"/>
+    <property name="DescriptionKey" value="plantedYucca3HarvestDesc"/>
+    <property name="DisplayInfo" value="Description"/>
+    <property name="DisplayType" value="blockMulti"/>
+    <property name="FilterTags" value="MC_outdoor,SC_crops"/>
+    <property name="HarvestOverdamage" value="false"/>
+    <property name="ImposterDontBlock" value="true"/>
+    <property name="IsDecoration" value="true"/>
+    <property name="IsTerrainDecoration" value="true"/>
+    <property name="LightOpacity" value="0"/>
+    <property name="Material" value="Mcorn"/>
+    <property name="Mesh" value="grass"/>
+    <property name="Model" value="Entities/Plants/plant_yucca_harvestPrefab"/>
+    <property name="MultiBlockDim" value="1,2,1"/>
+    <property name="PlantGrowing.FertileLevel" value="1"/>
+    <property name="Shape" value="ModelEntity"/>
+    <property name="SortOrder1" value="a090"/>
+    <property name="SortOrder2" value="0002"/>
+    <property name="Texture" value="395"/>
+    %s
 </block>`,
 		traits,
 		traits,

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -81,6 +81,8 @@ func (*Yucca) writeStage2(c chan string, traits string) {
 	<property name="CreativeMode" value="Dev"/>
 	<property name="CustomIconTint" value="00ff80"/>
 	<property name="Extends" value="plantedYucca1_%s"/>
+	<property name="DescriptionKey" value="plantedYucca2"/>
+	<property name="DisplayInfo" value="Description"/>
 	<property name="Model" value="Entities/Plants/plant_yucca_growthPrefab"/>
 	<property name="PlantGrowing.Next" value="plantedYucca3_%s"/>
 </block>`, traits, traits, traits, traits)

--- a/gen/blocks-researcher.go
+++ b/gen/blocks-researcher.go
@@ -79,15 +79,16 @@ func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
 	<property name="DescriptionKey" value="hotboxDesc"/>
 
 	<!-- recipe/unlock -->
-	<property name="UnlockedBy" value="perkAdvancedEngineering,workbenchSchematic"/>
-	<!-- TODO: use these ingredients for the recipe since they'll drop (thanks, workbench)
-		<drop event="Harvest" name="resourceScrapIron" count="200" tag="allHarvest"/>
-		<drop event="Harvest" name="resourceWood" count="20" tag="allHarvest"/>
-		<drop event="Harvest" name="terrStone" count="0" tool_category="Disassemble"/>
-		<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
-		<drop event="Harvest" name="resourceMechanicalParts" count="8" tag="salvageHarvest"/>
-		<drop event="Harvest" name="resourceWood" count="20" tag="salvageHarvest"/>
-	-->
+	<property name="UnlockedBy" value="perkLivingOffTheLand"/>
+	
+	<!-- salvage -->
+	<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
+
+	<!-- purchase price -->
 	<property name="EconomicValue" value="2000"/>
 
 	<!-- TODO: Heat -->
@@ -97,7 +98,7 @@ func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
 
 	<!-- TODO: Other -->
 	<property name="TakeDelay" value="5"/>
-	<property name="WorkstationIcon" value="ui_game_symbol_workbench"/>
+	<property name="WorkstationIcon" value="ui_game_symbol_crops"/>
 </block>`
 }
 

--- a/gen/blocks-researcher.go
+++ b/gen/blocks-researcher.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// CrystalHellBlocks is responsible for producing content for blocks.xml
-type CrystalHellBlocks struct{}
+// ResearcherBlocks is responsible for producing content for blocks.xml
+type ResearcherBlocks struct{}
 
 // GetPath returns file path for this producer
-func (*CrystalHellBlocks) GetPath() string {
-	return "Config-CrystalHell"
+func (*ResearcherBlocks) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (*CrystalHellBlocks) GetFilename() string {
+func (*ResearcherBlocks) GetFilename() string {
 	return "blocks.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *CrystalHellBlocks) Produce(c chan string) {
+func (p *ResearcherBlocks) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<append xpath="/blocks">`
@@ -30,8 +30,10 @@ func (p *CrystalHellBlocks) Produce(c chan string) {
 			if plant.IsCompatibleWith(trait1) {
 				plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c", trait1.Code))
 				for _, trait2 := range data.Traits {
-					if trait1.IsCompatibleWith(trait2) && plant.IsCompatibleWith(trait2) {
-						plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c%c", trait1.Code, trait2.Code))
+					if trait1.IsCompatibleWith(trait2) {
+						if plant.IsCompatibleWith(trait1) && plant.IsCompatibleWith(trait2) {
+							plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c%c", trait1.Code, trait2.Code))
+						}
 					}
 				}
 			}
@@ -42,7 +44,7 @@ func (p *CrystalHellBlocks) Produce(c chan string) {
 	c <- `</config>`
 }
 
-func (*CrystalHellBlocks) produceWorkstationHotBox(c chan string) {
+func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
 	c <- `<block name="hotbox">
 	<property name="Extends" value="workbench"/>
 	<property class="Workstation">
@@ -99,7 +101,7 @@ func (*CrystalHellBlocks) produceWorkstationHotBox(c chan string) {
 </block>`
 }
 
-func (*CrystalHellBlocks) produceBlockModifications(c chan string) {
+func (*ResearcherBlocks) produceBlockModifications(c chan string) {
 	// [U] Underground
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'U') and @stage='1']">
         <property name="PlantGrowing.LightLevelGrow" value="0" />
@@ -150,6 +152,6 @@ func (*CrystalHellBlocks) produceBlockModifications(c chan string) {
     </append>`
 }
 
-func (p *CrystalHellBlocks) getTarget() string {
-	return "CrystalHell"
+func (p *ResearcherBlocks) getTarget() string {
+	return "Researcher"
 }

--- a/gen/blocks-researcher.go
+++ b/gen/blocks-researcher.go
@@ -46,47 +46,47 @@ func (p *ResearcherBlocks) Produce(c chan string) {
 
 func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
 	c <- `<block name="hotbox">
-	<property name="Extends" value="workbench"/>
-	<property class="Workstation">
-		<property name="Modules" value="output"/>
-		<property name="CraftingAreaRecipes" value="hotbox"/>
-	</property>
-	
-	<property name="ModelOffset" value="1,0,1"/>
-	<property name="MultiBlockDim" value="1,1,1"/>
-	<property name="StabilitySupport" value="true"/>
-	<property name="IsTerrainDecoration" value="false"/>
-	<property name="DisplayType" value="blockMulti"/>
-	
-	<!-- from farmPlotRaised shape -->
-	<property name="Path" value="solid"/>  <!-- This is a hint for the AI; see XML.txt -->
-	<property name="Shape" value="New"/>
-	<property name="Model" value="farm_plot_raised"/>
-	<property name="CustomIcon" value="shapeFarmPlotRaised"/>
-	<property name="ImposterExchange" value="imposterBlock"/>
-	<property name="UseGlobalUV" value="G,L,L,L,L,L"/>
+    <property name="Extends" value="workbench"/>
+    <property class="Workstation">
+        <property name="Modules" value="output"/>
+        <property name="CraftingAreaRecipes" value="hotbox"/>
+    </property>
+    
+    <property name="ModelOffset" value="1,0,1"/>
+    <property name="MultiBlockDim" value="1,1,1"/>
+    <property name="StabilitySupport" value="true"/>
+    <property name="IsTerrainDecoration" value="false"/>
+    <property name="DisplayType" value="blockMulti"/>
+    
+    <!-- from farmPlotRaised shape -->
+    <property name="Path" value="solid"/>  <!-- This is a hint for the AI; see XML.txt -->
+    <property name="Shape" value="New"/>
+    <property name="Model" value="farm_plot_raised"/>
+    <property name="CustomIcon" value="shapeFarmPlotRaised"/>
+    <property name="ImposterExchange" value="imposterBlock"/>
+    <property name="UseGlobalUV" value="G,L,L,L,L,L"/>
 
-	<!-- from corrugatedMetalShapes -->
-	<property name="Texture" value="194"/>
-	<property name="UiBackgroundTexture" value="194"/>
+    <!-- from corrugatedMetalShapes -->
+    <property name="Texture" value="194"/>
+    <property name="UiBackgroundTexture" value="194"/>
 
-	<!-- audio -->
-	<property name="OpenSound" value="drone_storage_open"/>
-	<property name="CloseSound" value="drone_storage_close"/>
-	
-	<!-- Localization -->
-	<property name="WorkstationJournalTip" value="hotboxTip"/>
-	<property name="DescriptionKey" value="hotboxDesc"/>
+    <!-- audio -->
+    <property name="OpenSound" value="drone_storage_open"/>
+    <property name="CloseSound" value="drone_storage_close"/>
+    
+    <!-- Localization -->
+    <property name="WorkstationJournalTip" value="hotboxTip"/>
+    <property name="DescriptionKey" value="hotboxDesc"/>
 
-	<!-- recipe/unlock -->
-	<property name="UnlockedBy" value="perkLivingOffTheLand"/>
-	
-	<!-- salvage -->
-	<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
+    <!-- recipe/unlock -->
+    <property name="UnlockedBy" value="perkLivingOffTheLand"/>
+    
+    <!-- salvage -->
+    <drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
 
     <!-- repair -->
     <property class="RepairItems">
@@ -97,17 +97,17 @@ func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
         <property name="resourceClayLump" value="50" />
     </property>
 
-	<!-- purchase price -->
-	<property name="EconomicValue" value="2000"/>
+    <!-- purchase price -->
+    <property name="EconomicValue" value="2000"/>
 
-	<!-- TODO: Heat -->
-	<property name="HeatMapStrength" value="2"/>
-	<property name="HeatMapTime" value="5000"/>
-	<property name="HeatMapFrequency" value="1000"/>
+    <!-- TODO: Heat -->
+    <property name="HeatMapStrength" value="2"/>
+    <property name="HeatMapTime" value="5000"/>
+    <property name="HeatMapFrequency" value="1000"/>
 
-	<!-- TODO: Other -->
-	<property name="TakeDelay" value="5"/>
-	<property name="WorkstationIcon" value="ui_game_symbol_crops"/>
+    <!-- TODO: Other -->
+    <property name="TakeDelay" value="5"/>
+    <property name="WorkstationIcon" value="ui_game_symbol_crops"/>
 </block>`
 }
 
@@ -131,7 +131,7 @@ func (*ResearcherBlocks) produceBlockModifications(c chan string) {
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
         <property name="Collide" value="movement,melee,arrow" />
-		<property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
+        <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
         <property name="Explosion.ParticleIndex" value="11" />
@@ -144,7 +144,7 @@ func (*ResearcherBlocks) produceBlockModifications(c chan string) {
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
         <property name="Collide" value="movement,melee,arrow" />
-		<property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
+        <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
         <property name="Explosion.ParticleIndex" value="11" />

--- a/gen/blocks-researcher.go
+++ b/gen/blocks-researcher.go
@@ -88,6 +88,15 @@ func (*ResearcherBlocks) produceWorkstationHotBox(c chan string) {
 	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
 	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
 
+    <!-- repair -->
+    <property class="RepairItems">
+        <property name="resourceForgedIron" value="50" />
+        <property name="resourceMechanicalParts" value="8" />
+        <property name="resourceWood" value="25" />
+        <property name="resourcePotassiumNitratePowder" value="10" />
+        <property name="resourceClayLump" value="50" />
+    </property>
+
 	<!-- purchase price -->
 	<property name="EconomicValue" value="2000"/>
 

--- a/gen/blocks-researcher.go
+++ b/gen/blocks-researcher.go
@@ -130,7 +130,7 @@ func (*ResearcherBlocks) produceBlockModifications(c chan string) {
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'E') and @stage='3' and not (@traits='EE')]">
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
-        <property name="Collide" value="movement,melee,arrow" />
+        <property name="Collide" value="melee,arrow" />
         <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
@@ -143,7 +143,7 @@ func (*ResearcherBlocks) produceBlockModifications(c chan string) {
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'EE') and @stage='3']">
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
-        <property name="Collide" value="movement,melee,arrow" />
+        <property name="Collide" value="melee,arrow" />
         <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />

--- a/gen/blocks-standard.go
+++ b/gen/blocks-standard.go
@@ -128,7 +128,7 @@ func (*StandardBlocks) produceBlockModifications(c chan string) {
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'E') and @stage='3' and not (@traits='EE')]">
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
-        <property name="Collide" value="movement,melee,arrow" />
+        <property name="Collide" value="melee,arrow" />
         <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
@@ -141,7 +141,7 @@ func (*StandardBlocks) produceBlockModifications(c chan string) {
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'EE') and @stage='3']">
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
-        <property name="Collide" value="movement,melee,arrow" />
+        <property name="Collide" value="melee,arrow" />
         <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />

--- a/gen/blocks-standard.go
+++ b/gen/blocks-standard.go
@@ -44,47 +44,47 @@ func (p *StandardBlocks) Produce(c chan string) {
 
 func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
 	c <- `<block name="hotbox">
-	<property name="Extends" value="workbench"/>
-	<property class="Workstation">
-		<property name="Modules" value="output"/>
-		<property name="CraftingAreaRecipes" value="hotbox"/>
-	</property>
-	
-	<property name="ModelOffset" value="1,0,1"/>
-	<property name="MultiBlockDim" value="1,1,1"/>
-	<property name="StabilitySupport" value="true"/>
-	<property name="IsTerrainDecoration" value="false"/>
-	<property name="DisplayType" value="blockMulti"/>
-	
-	<!-- from farmPlotRaised shape -->
-	<property name="Path" value="solid"/>  <!-- This is a hint for the AI; see XML.txt -->
-	<property name="Shape" value="New"/>
-	<property name="Model" value="farm_plot_raised"/>
-	<property name="CustomIcon" value="shapeFarmPlotRaised"/>
-	<property name="ImposterExchange" value="imposterBlock"/>
-	<property name="UseGlobalUV" value="G,L,L,L,L,L"/>
+    <property name="Extends" value="workbench"/>
+    <property class="Workstation">
+        <property name="Modules" value="output"/>
+        <property name="CraftingAreaRecipes" value="hotbox"/>
+    </property>
+    
+    <property name="ModelOffset" value="1,0,1"/>
+    <property name="MultiBlockDim" value="1,1,1"/>
+    <property name="StabilitySupport" value="true"/>
+    <property name="IsTerrainDecoration" value="false"/>
+    <property name="DisplayType" value="blockMulti"/>
+    
+    <!-- from farmPlotRaised shape -->
+    <property name="Path" value="solid"/>  <!-- This is a hint for the AI; see XML.txt -->
+    <property name="Shape" value="New"/>
+    <property name="Model" value="farm_plot_raised"/>
+    <property name="CustomIcon" value="shapeFarmPlotRaised"/>
+    <property name="ImposterExchange" value="imposterBlock"/>
+    <property name="UseGlobalUV" value="G,L,L,L,L,L"/>
 
-	<!-- from corrugatedMetalShapes -->
-	<property name="Texture" value="194"/>
-	<property name="UiBackgroundTexture" value="194"/>
+    <!-- from corrugatedMetalShapes -->
+    <property name="Texture" value="194"/>
+    <property name="UiBackgroundTexture" value="194"/>
 
-	<!-- audio -->
-	<property name="OpenSound" value="drone_storage_open"/>
-	<property name="CloseSound" value="drone_storage_close"/>
-	
-	<!-- Localization -->
-	<property name="WorkstationJournalTip" value="hotboxTip"/>
-	<property name="DescriptionKey" value="hotboxDesc"/>
+    <!-- audio -->
+    <property name="OpenSound" value="drone_storage_open"/>
+    <property name="CloseSound" value="drone_storage_close"/>
+    
+    <!-- Localization -->
+    <property name="WorkstationJournalTip" value="hotboxTip"/>
+    <property name="DescriptionKey" value="hotboxDesc"/>
 
-	<!-- recipe/unlock -->
-	<property name="UnlockedBy" value="perkLivingOffTheLand"/>
-	
-	<!-- salvage -->
-	<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
-	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
+    <!-- recipe/unlock -->
+    <property name="UnlockedBy" value="perkLivingOffTheLand"/>
+    
+    <!-- salvage -->
+    <drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
+    <drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
 
     <!-- repair -->
     <property class="RepairItems">
@@ -95,17 +95,17 @@ func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
         <property name="resourceClayLump" value="50" />
     </property>
 
-	<!-- purchase price -->
-	<property name="EconomicValue" value="2000"/>
+    <!-- purchase price -->
+    <property name="EconomicValue" value="2000"/>
 
-	<!-- TODO: Heat -->
-	<property name="HeatMapStrength" value="2"/>
-	<property name="HeatMapTime" value="5000"/>
-	<property name="HeatMapFrequency" value="1000"/>
+    <!-- TODO: Heat -->
+    <property name="HeatMapStrength" value="2"/>
+    <property name="HeatMapTime" value="5000"/>
+    <property name="HeatMapFrequency" value="1000"/>
 
-	<!-- TODO: Other -->
-	<property name="TakeDelay" value="5"/>
-	<property name="WorkstationIcon" value="ui_game_symbol_crops"/>
+    <!-- TODO: Other -->
+    <property name="TakeDelay" value="5"/>
+    <property name="WorkstationIcon" value="ui_game_symbol_crops"/>
 </block>`
 }
 
@@ -129,7 +129,7 @@ func (*StandardBlocks) produceBlockModifications(c chan string) {
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
         <property name="Collide" value="movement,melee,arrow" />
-		<property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
+        <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
         <property name="Explosion.ParticleIndex" value="11" />
@@ -142,7 +142,7 @@ func (*StandardBlocks) produceBlockModifications(c chan string) {
         <property name="Class" value="Mine" /> <!-- a mine destroyed by an *explosion* only has a 33 percent chance to detonate -->
         <property name="Tags" value="Mine" />
         <property name="Collide" value="movement,melee,arrow" />
-		<property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
+        <property name="MaxDamage" value="1" /> <!-- reduced from 4 -->
         <property name="TriggerDelay" value="0.1" /> <!-- reduced from 0.5 -->
         <property name="TriggerSound" value="landmine_trigger" />
         <property name="Explosion.ParticleIndex" value="11" />

--- a/gen/blocks-standard.go
+++ b/gen/blocks-standard.go
@@ -86,6 +86,15 @@ func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
 	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
 	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
 
+    <!-- repair -->
+    <property class="RepairItems">
+        <property name="resourceForgedIron" value="50" />
+        <property name="resourceMechanicalParts" value="8" />
+        <property name="resourceWood" value="25" />
+        <property name="resourcePotassiumNitratePowder" value="10" />
+        <property name="resourceClayLump" value="50" />
+    </property>
+
 	<!-- purchase price -->
 	<property name="EconomicValue" value="2000"/>
 

--- a/gen/blocks-standard.go
+++ b/gen/blocks-standard.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// VanillaBlocks is responsible for producing content for blocks.xml
-type VanillaBlocks struct{}
+// StandardBlocks is responsible for producing content for blocks.xml
+type StandardBlocks struct{}
 
 // GetPath returns file path for this producer
-func (*VanillaBlocks) GetPath() string {
-	return "Config-Vanilla"
+func (*StandardBlocks) GetPath() string {
+	return "Config-Standard"
 }
 
 // GetFilename returns filename for this producer
-func (*VanillaBlocks) GetFilename() string {
+func (*StandardBlocks) GetFilename() string {
 	return "blocks.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *VanillaBlocks) Produce(c chan string) {
+func (p *StandardBlocks) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<append xpath="/blocks">`
@@ -30,10 +30,8 @@ func (p *VanillaBlocks) Produce(c chan string) {
 			if plant.IsCompatibleWith(trait1) {
 				plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c", trait1.Code))
 				for _, trait2 := range data.Traits {
-					if trait1.IsCompatibleWith(trait2) {
-						if plant.IsCompatibleWith(trait1) && plant.IsCompatibleWith(trait2) {
-							plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c%c", trait1.Code, trait2.Code))
-						}
+					if trait1.IsCompatibleWith(trait2) && plant.IsCompatibleWith(trait2) {
+						plant.WriteBlockStages(c, p.getTarget(), fmt.Sprintf("%c%c", trait1.Code, trait2.Code))
 					}
 				}
 			}
@@ -44,7 +42,7 @@ func (p *VanillaBlocks) Produce(c chan string) {
 	c <- `</config>`
 }
 
-func (*VanillaBlocks) produceWorkstationHotBox(c chan string) {
+func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
 	c <- `<block name="hotbox">
 	<property name="Extends" value="workbench"/>
 	<property class="Workstation">
@@ -101,7 +99,7 @@ func (*VanillaBlocks) produceWorkstationHotBox(c chan string) {
 </block>`
 }
 
-func (*VanillaBlocks) produceBlockModifications(c chan string) {
+func (*StandardBlocks) produceBlockModifications(c chan string) {
 	// [U] Underground
 	c <- `    <append xpath="/blocks/block[contains(@traits, 'U') and @stage='1']">
         <property name="PlantGrowing.LightLevelGrow" value="0" />
@@ -152,6 +150,6 @@ func (*VanillaBlocks) produceBlockModifications(c chan string) {
     </append>`
 }
 
-func (p *VanillaBlocks) getTarget() string {
-	return "Vanilla"
+func (p *StandardBlocks) getTarget() string {
+	return "Standard"
 }

--- a/gen/blocks-standard.go
+++ b/gen/blocks-standard.go
@@ -77,15 +77,16 @@ func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
 	<property name="DescriptionKey" value="hotboxDesc"/>
 
 	<!-- recipe/unlock -->
-	<property name="UnlockedBy" value="perkAdvancedEngineering,workbenchSchematic"/>
-	<!-- TODO: use these ingredients for the recipe since they'll drop (thanks, workbench)
-		<drop event="Harvest" name="resourceScrapIron" count="200" tag="allHarvest"/>
-		<drop event="Harvest" name="resourceWood" count="20" tag="allHarvest"/>
-		<drop event="Harvest" name="terrStone" count="0" tool_category="Disassemble"/>
-		<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
-		<drop event="Harvest" name="resourceMechanicalParts" count="8" tag="salvageHarvest"/>
-		<drop event="Harvest" name="resourceWood" count="20" tag="salvageHarvest"/>
-	-->
+	<property name="UnlockedBy" value="perkLivingOffTheLand"/>
+	
+	<!-- salvage -->
+	<drop event="Harvest" name="resourceForgedIron" count="10" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceMechanicalParts" count="1" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceWood" count="10" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourcePotassiumNitratePowder" count="2" tag="salvageHarvest"/>
+	<drop event="Harvest" name="resourceClayLump" count="10" tag="salvageHarvest"/>
+
+	<!-- purchase price -->
 	<property name="EconomicValue" value="2000"/>
 
 	<!-- TODO: Heat -->
@@ -95,7 +96,7 @@ func (*StandardBlocks) produceWorkstationHotBox(c chan string) {
 
 	<!-- TODO: Other -->
 	<property name="TakeDelay" value="5"/>
-	<property name="WorkstationIcon" value="ui_game_symbol_workbench"/>
+	<property name="WorkstationIcon" value="ui_game_symbol_crops"/>
 </block>`
 }
 

--- a/gen/crystalhell-recipes.go
+++ b/gen/crystalhell-recipes.go
@@ -51,14 +51,22 @@ func (*CrystalHellRecipes) produceHotBoxRecipe(c chan string) {
 func (p *CrystalHellRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
-		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox">
+		enhancedSeedCraftTime := plant.GetCraftTime() * 450
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="">
     <ingredient name="planted%s1" count="1"/>
     <ingredient name="foodRottingFlesh" count="1"/>
     <ingredient name="resourceCloth" count="1"/>
     <ingredient name="resourceYuccaFibers" count="2"/>
 </recipe>`,
 			plant.GetName(),
-			plant.GetCraftTime()*450,
+			enhancedSeedCraftTime,
+			plant.GetName())
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox">
+    <ingredient name="planted%s1" count="1"/>
+    <ingredient name="foodRottingFlesh" count="1"/>
+</recipe>`,
+			plant.GetName(),
+			enhancedSeedCraftTime,
 			plant.GetName())
 	case 1:
 		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" craft_area="hotbox">

--- a/gen/items-researcher.go
+++ b/gen/items-researcher.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// VanillaItems is responsible for producing content for items.xml
-type VanillaItems struct{}
+// ResearcherItems is responsible for producing content for items.xml
+type ResearcherItems struct{}
 
 // GetPath returns file path for this producer
-func (p *VanillaItems) GetPath() string {
-	return "Config-Vanilla"
+func (p *ResearcherItems) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (p *VanillaItems) GetFilename() string {
+func (p *ResearcherItems) GetFilename() string {
 	return "items.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *VanillaItems) Produce(c chan string) {
+func (p *ResearcherItems) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/items">`
 	for _, plant := range data.Plants {
@@ -40,7 +40,7 @@ func (p *VanillaItems) Produce(c chan string) {
 	c <- `</append></config>`
 }
 
-func (p *VanillaItems) produceSchematic(c chan string, plant data.Plant, traits ...data.Trait) {
+func (p *ResearcherItems) produceSchematic(c chan string, plant data.Plant, traits ...data.Trait) {
 	var iconName string
 	if plant.GetName() == "GraceCorn" {
 		iconName = `plantedCorn1"/><property name="CustomIconTint" value="ff9f9f`

--- a/gen/items-researcher.go
+++ b/gen/items-researcher.go
@@ -71,9 +71,9 @@ func (p *ResearcherItems) produceSchematic(c chan string, plant data.Plant, trai
     <property name="Group" value="%s"/>
     <property name="UnlockedBy" value="perkLivingOffTheLand"/>
     <property name="Unlocks" value="%s"/>
-	<effect_group>
+    <effect_group>
         <triggered_effect trigger="onSelfPrimaryActionEnd" action="ModifyCVar" cvar="%s" operation="set" value="1"/>
-        <triggered_effect trigger="onSelfPrimaryActionEnd" action="GiveExp" exp="50"/>	
+        <triggered_effect trigger="onSelfPrimaryActionEnd" action="GiveExp" exp="50"/>    
     </effect_group>
 </item>`,
 		plant.GetSchematicName(traitsStr), iconName, group, unlocks, unlocks)

--- a/gen/localization-researcher.go
+++ b/gen/localization-researcher.go
@@ -5,32 +5,35 @@ import (
 	"fmt"
 )
 
-// CrystalHellLocalization is responsible for producing content for Localization.txt
-type CrystalHellLocalization struct{}
+// ResearcherLocalization is responsible for producing content for Localization.txt
+type ResearcherLocalization struct{}
 
 // GetPath returns file path for this producer
-func (*CrystalHellLocalization) GetPath() string {
-	return "Config-CrystalHell"
+func (*ResearcherLocalization) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (*CrystalHellLocalization) GetFilename() string {
+func (*ResearcherLocalization) GetFilename() string {
 	return "Localization.txt"
 }
 
 // Produce xml data to the provided channel
-func (p *CrystalHellLocalization) Produce(c chan string) {
+func (p *ResearcherLocalization) Produce(c chan string) {
 	defer close(c)
 	c <- "Key,File,Type,english"
 	p.produceHotBoxLocalization(c)
 	p.produceThornyBuffLocalization(c)
 	for _, plant := range data.Plants {
+		p.produceSchematicLocalization(c, plant)
 		p.producePlantLocalization(c, plant)
 		for _, trait1 := range data.Traits {
 			if plant.IsCompatibleWith(trait1) {
+				p.produceSchematicLocalization(c, plant, trait1)
 				p.producePlantLocalization(c, plant, trait1)
 				for _, trait2 := range data.Traits {
 					if trait1.IsCompatibleWith(trait2) && plant.IsCompatibleWith(trait2) {
+						p.produceSchematicLocalization(c, plant, trait1, trait2)
 						p.producePlantLocalization(c, plant, trait1, trait2)
 					}
 				}
@@ -39,32 +42,36 @@ func (p *CrystalHellLocalization) Produce(c chan string) {
 	}
 }
 
-func (*CrystalHellLocalization) produceHotBoxLocalization(c chan string) {
+func (*ResearcherLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `hotbox,blocks,Workstation,Hot Box`
 	c <- `hotboxDesc,blocks,Workstation,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip,Journal Tip,,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip_title,Journal Tip,,Hot Box`
 
 	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer`
-	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for.`
+	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,"Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for."`
 	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist`
-	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
+	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,"Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight."`
 	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius`
-	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!`
+	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,"Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!"`
 
-	c <- `lblCategoryTier1Seeds,UI,Tooltip,Tier 1 Seed Enhancements`
-	c <- `lblCategoryTier2Seeds,UI,Tooltip,Tier 2 Seed Enhancements`
-	c <- `lblCategoryTier3Seeds,UI,Tooltip,Tier 3 Seed Enhancements`
+	c <- `lblCategoryTier1SeedResearch,UI,Tooltip,Seed Enhancement Research`
+	c <- `lblCategoryTier1Seeds,UI,Tooltip,Enhance Seed`
+	c <- `lblCategoryTier2SeedResearch,UI,Tooltip,Seed Trait Research`
+	c <- `lblCategoryTier2Seeds,UI,Tooltip,Add Seed Trait`
+	c <- `lblCategoryTier3SeedResearch,UI,Tooltip,Advanced Seed Trait Research`
+	c <- `lblCategoryTier3Seeds,UI,Tooltip,Add Another Seed Trait`
+
 }
 
-func (*CrystalHellLocalization) produceThornyBuffLocalization(c chan string) {
+func (*ResearcherLocalization) produceThornyBuffLocalization(c chan string) {
 	c <- `buffInjuryThornsName,buffs,Buff,Thorns`
 	c <- `buffInjuryCriticalThornsName,buffs,Buff,Critical Thorns`
 	c <- `buffInjuryThornsDesc,buffs,Buff,"Your skin is pierced by the thorny barbs of an aggressively engineered plant.\n\nStep away from the plant to avoid further injury."`
 	c <- `buffInjuryThornsTooltip,buffs,Buff,The thorns on this plant are cutting into your skin.`
 }
 
-func (*CrystalHellLocalization) producePlantLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
+func (*ResearcherLocalization) producePlantLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
 		c <- fmt.Sprintf(`planted%s1_,blocks,Farming,"%s (Seed, Enhanced)"`,
@@ -124,6 +131,25 @@ func (*CrystalHellLocalization) producePlantLocalization(c chan string, plant da
 				traits[0].GetTraitDescription(),
 				traits[1].GetTraitDescription(),
 				getHotBoxRequirementTip())
+		}
+	}
+}
+
+func (*ResearcherLocalization) produceSchematicLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
+	switch len(traits) {
+	case 0:
+		c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, Enhanced) Recipe"`,
+			plant.GetSchematicName(""), plant.GetDisplayName())
+	case 1:
+		c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s) Recipe"`,
+			plant.GetSchematicName(string(traits[0].Code)), plant.GetDisplayName(), traits[0].Name)
+	case 2:
+		if traits[0].Code == traits[1].Code {
+			c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s) Recipe"`,
+				plant.GetSchematicName(string(traits[0].Code)+string(traits[1].Code)), plant.GetDisplayName(), traits[0].DoubleName)
+		} else {
+			c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s, %s) Recipe"`,
+				plant.GetSchematicName(string(traits[0].Code)+string(traits[1].Code)), plant.GetDisplayName(), traits[0].Name, traits[1].Name)
 		}
 	}
 }

--- a/gen/localization-researcher.go
+++ b/gen/localization-researcher.go
@@ -56,11 +56,11 @@ func (*ResearcherLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,"Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!"`
 
 	c <- `lblCategoryTier1SeedResearch,UI,Tooltip,Seed Enhancement Research`
-	c <- `lblCategoryTier1Seeds,UI,Tooltip,Enhance Seed`
-	c <- `lblCategoryTier2SeedResearch,UI,Tooltip,Seed Trait Research`
-	c <- `lblCategoryTier2Seeds,UI,Tooltip,Add Seed Trait`
-	c <- `lblCategoryTier3SeedResearch,UI,Tooltip,Advanced Seed Trait Research`
-	c <- `lblCategoryTier3Seeds,UI,Tooltip,Add Another Seed Trait`
+	c <- `lblCategoryTier1Seeds,UI,Tooltip,Seed Enhancement`
+	c <- `lblCategoryTier2SeedResearch,UI,Tooltip,First Trait Research`
+	c <- `lblCategoryTier2Seeds,UI,Tooltip,First Trait`
+	c <- `lblCategoryTier3SeedResearch,UI,Tooltip,Second Trait Research`
+	c <- `lblCategoryTier3Seeds,UI,Tooltip,Second Trait`
 
 }
 

--- a/gen/localization-researcher.go
+++ b/gen/localization-researcher.go
@@ -52,9 +52,9 @@ func (*ResearcherLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `perkLivingOffTheLandDesc,progression,perk For,Specialize in harvesting more crops using your hands or a tool.\n\n[FF8000][MOD] This perk has 2 new skill levels and added unlocks for level 3.`
 
 	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer [FF8000][MOD]`
-	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,"Triple the harvest of wild or planted crops.\n\nCraft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for."`
+	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,Triple the harvest of wild or planted crops.\n\nCraft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for.`
 	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist [FF8000][MOD]`
-	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,"Add a new Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
+	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,Add a new Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
 	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius [FF8000][MOD]`
 	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Add a Second Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
 

--- a/gen/localization-researcher.go
+++ b/gen/localization-researcher.go
@@ -48,12 +48,15 @@ func (*ResearcherLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `hotboxTip,Journal Tip,,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip_title,Journal Tip,,Hot Box`
 
-	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer`
-	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,"Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for."`
-	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist`
-	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,"Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight."`
-	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius`
-	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,"Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!"`
+	c <- `perkLivingOffTheLandName,progression,perk For,Living off the Land [FF8000][MOD]`
+	c <- `perkLivingOffTheLandDesc,progression,perk For,Specialize in harvesting more crops using your hands or a tool.\n\n[FF8000][MOD] This perk has 2 new skill levels and added unlocks for level 3.`
+
+	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,"Triple the harvest of wild or planted crops.\n\nCraft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for."`
+	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,"Add a new Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
+	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Add a Second Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
 
 	c <- `lblCategoryTier1SeedResearch,UI,Tooltip,Seed Enhancement Research`
 	c <- `lblCategoryTier1Seeds,UI,Tooltip,Seed Enhancement`

--- a/gen/localization-standard.go
+++ b/gen/localization-standard.go
@@ -5,35 +5,32 @@ import (
 	"fmt"
 )
 
-// VanillaLocalization is responsible for producing content for Localization.txt
-type VanillaLocalization struct{}
+// StandardLocalization is responsible for producing content for Localization.txt
+type StandardLocalization struct{}
 
 // GetPath returns file path for this producer
-func (*VanillaLocalization) GetPath() string {
-	return "Config-Vanilla"
+func (*StandardLocalization) GetPath() string {
+	return "Config-Standard"
 }
 
 // GetFilename returns filename for this producer
-func (*VanillaLocalization) GetFilename() string {
+func (*StandardLocalization) GetFilename() string {
 	return "Localization.txt"
 }
 
 // Produce xml data to the provided channel
-func (p *VanillaLocalization) Produce(c chan string) {
+func (p *StandardLocalization) Produce(c chan string) {
 	defer close(c)
 	c <- "Key,File,Type,english"
 	p.produceHotBoxLocalization(c)
 	p.produceThornyBuffLocalization(c)
 	for _, plant := range data.Plants {
-		p.produceSchematicLocalization(c, plant)
 		p.producePlantLocalization(c, plant)
 		for _, trait1 := range data.Traits {
 			if plant.IsCompatibleWith(trait1) {
-				p.produceSchematicLocalization(c, plant, trait1)
 				p.producePlantLocalization(c, plant, trait1)
 				for _, trait2 := range data.Traits {
 					if trait1.IsCompatibleWith(trait2) && plant.IsCompatibleWith(trait2) {
-						p.produceSchematicLocalization(c, plant, trait1, trait2)
 						p.producePlantLocalization(c, plant, trait1, trait2)
 					}
 				}
@@ -42,36 +39,32 @@ func (p *VanillaLocalization) Produce(c chan string) {
 	}
 }
 
-func (*VanillaLocalization) produceHotBoxLocalization(c chan string) {
+func (*StandardLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `hotbox,blocks,Workstation,Hot Box`
 	c <- `hotboxDesc,blocks,Workstation,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip,Journal Tip,,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip_title,Journal Tip,,Hot Box`
 
 	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer`
-	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,"Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for."`
+	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for.`
 	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist`
-	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,"Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight."`
+	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
 	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius`
-	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,"Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!"`
+	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!`
 
-	c <- `lblCategoryTier1SeedResearch,UI,Tooltip,Seed Enhancement Research`
-	c <- `lblCategoryTier1Seeds,UI,Tooltip,Enhance Seed`
-	c <- `lblCategoryTier2SeedResearch,UI,Tooltip,Seed Trait Research`
-	c <- `lblCategoryTier2Seeds,UI,Tooltip,Add Seed Trait`
-	c <- `lblCategoryTier3SeedResearch,UI,Tooltip,Advanced Seed Trait Research`
-	c <- `lblCategoryTier3Seeds,UI,Tooltip,Add Another Seed Trait`
-
+	c <- `lblCategoryTier1Seeds,UI,Tooltip,Tier 1 Seed Enhancements`
+	c <- `lblCategoryTier2Seeds,UI,Tooltip,Tier 2 Seed Enhancements`
+	c <- `lblCategoryTier3Seeds,UI,Tooltip,Tier 3 Seed Enhancements`
 }
 
-func (*VanillaLocalization) produceThornyBuffLocalization(c chan string) {
+func (*StandardLocalization) produceThornyBuffLocalization(c chan string) {
 	c <- `buffInjuryThornsName,buffs,Buff,Thorns`
 	c <- `buffInjuryCriticalThornsName,buffs,Buff,Critical Thorns`
 	c <- `buffInjuryThornsDesc,buffs,Buff,"Your skin is pierced by the thorny barbs of an aggressively engineered plant.\n\nStep away from the plant to avoid further injury."`
 	c <- `buffInjuryThornsTooltip,buffs,Buff,The thorns on this plant are cutting into your skin.`
 }
 
-func (*VanillaLocalization) producePlantLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
+func (*StandardLocalization) producePlantLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
 		c <- fmt.Sprintf(`planted%s1_,blocks,Farming,"%s (Seed, Enhanced)"`,
@@ -131,25 +124,6 @@ func (*VanillaLocalization) producePlantLocalization(c chan string, plant data.P
 				traits[0].GetTraitDescription(),
 				traits[1].GetTraitDescription(),
 				getHotBoxRequirementTip())
-		}
-	}
-}
-
-func (*VanillaLocalization) produceSchematicLocalization(c chan string, plant data.Plant, traits ...data.Trait) {
-	switch len(traits) {
-	case 0:
-		c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, Enhanced) Recipe"`,
-			plant.GetSchematicName(""), plant.GetDisplayName())
-	case 1:
-		c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s) Recipe"`,
-			plant.GetSchematicName(string(traits[0].Code)), plant.GetDisplayName(), traits[0].Name)
-	case 2:
-		if traits[0].Code == traits[1].Code {
-			c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s) Recipe"`,
-				plant.GetSchematicName(string(traits[0].Code)+string(traits[1].Code)), plant.GetDisplayName(), traits[0].DoubleName)
-		} else {
-			c <- fmt.Sprintf(`%s,blocks,Farming,"%s (Seed, %s, %s) Recipe"`,
-				plant.GetSchematicName(string(traits[0].Code)+string(traits[1].Code)), plant.GetDisplayName(), traits[0].Name, traits[1].Name)
 		}
 	}
 }

--- a/gen/localization-standard.go
+++ b/gen/localization-standard.go
@@ -45,12 +45,15 @@ func (*StandardLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `hotboxTip,Journal Tip,,"The Hot Box is a simple workstation that allows enhanced seeds to absorb various materials and take on new traits."`
 	c <- `hotboxTip_title,Journal Tip,,Hot Box`
 
-	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer`
-	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,Triple the harvest of wild or planted crops. Craft Hot Boxes and Enhanced Seeds that you'll be able to research special traits for.`
-	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist`
-	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,Craft a Trait into enhanced seeds.\n\nTraits can be used to add a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
-	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius`
-	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!`
+	c <- `perkLivingOffTheLandName,progression,perk For,Living off the Land [FF8000][MOD]`
+	c <- `perkLivingOffTheLandDesc,progression,perk For,Specialize in harvesting more crops using your hands or a tool.\n\n[FF8000][MOD] This perk has 2 new skill levels and added unlocks for level 3.`
+
+	c <- `perkLivingOffTheLandRank3Desc,progression,perk For,Farmer [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank3LongDesc,progression,perk For,Triple the harvest of wild or planted crops.\n\nCraft Hot Boxes and Enhanced Seeds that you'll be able to add special traits to.`
+	c <- `perkLivingOffTheLandRank4Desc,progression,perk For,Mad Scientist [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank4LongDesc,progression,perk For,Add a new Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
+	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius [FF8000][MOD]`
+	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Add a Second Trait to enhanced seeds.\n\nAdded Traits can provide a wide variety of properties to a seed; ranging from increasing crop yield to allowing plants to grow without sunlight.`
 
 	c <- `lblCategoryTier1Seeds,UI,Tooltip,Seed Enhancement`
 	c <- `lblCategoryTier2Seeds,UI,Tooltip,First Trait`

--- a/gen/localization-standard.go
+++ b/gen/localization-standard.go
@@ -52,9 +52,9 @@ func (*StandardLocalization) produceHotBoxLocalization(c chan string) {
 	c <- `perkLivingOffTheLandRank5Desc,progression,perk For,Agricultural Genius`
 	c <- `perkLivingOffTheLandRank5LongDesc,progression,perk For,Craft a second Trait into enhanced seeds.\n\nDouble the Traits,\nDouble the fun!`
 
-	c <- `lblCategoryTier1Seeds,UI,Tooltip,Tier 1 Seed Enhancements`
-	c <- `lblCategoryTier2Seeds,UI,Tooltip,Tier 2 Seed Enhancements`
-	c <- `lblCategoryTier3Seeds,UI,Tooltip,Tier 3 Seed Enhancements`
+	c <- `lblCategoryTier1Seeds,UI,Tooltip,Seed Enhancement`
+	c <- `lblCategoryTier2Seeds,UI,Tooltip,First Trait`
+	c <- `lblCategoryTier3Seeds,UI,Tooltip,Second Trait`
 }
 
 func (*StandardLocalization) produceThornyBuffLocalization(c chan string) {

--- a/gen/progression-researcher.go
+++ b/gen/progression-researcher.go
@@ -24,6 +24,10 @@ func (p *ResearcherProgression) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='cropHarvest,wildCropsHarvest']/@level">1,2,3,4,5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='cropHarvest,wildCropsHarvest']/@value">1,1,2,2,2</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='bonusCropHarvest']/@level">2,3,4,5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='bonusCropHarvest']/@value">1,1,1,1</set>`
 	c <- `<append xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group">
     <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="hotbox" />`
 	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="%s" />`,

--- a/gen/progression-researcher.go
+++ b/gen/progression-researcher.go
@@ -25,12 +25,12 @@ func (p *ResearcherProgression) Produce(c chan string) {
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
 	c <- `<append xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group">
-    <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3" value="1" tags="hotbox" />`
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3" value="1" tags="%s" />`,
+    <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="hotbox" />`
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsEnhanced(), ","))
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="4" value="1" tags="%s" />`,
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="4,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsSingles(), ","))
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="5" value="1" tags="%s" />`,
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="5,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsDoubles(), ","))
 	c <- `</append>`
 	c <- `</config>`

--- a/gen/progression-researcher.go
+++ b/gen/progression-researcher.go
@@ -6,21 +6,21 @@ import (
 	"strings"
 )
 
-// CrystalHellProgression is responsible for producing content for progression.xml
-type CrystalHellProgression struct{}
+// ResearcherProgression is responsible for producing content for progression.xml
+type ResearcherProgression struct{}
 
 // GetPath returns file path for this producer
-func (*CrystalHellProgression) GetPath() string {
-	return "Config-CrystalHell"
+func (*ResearcherProgression) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (*CrystalHellProgression) GetFilename() string {
+func (*ResearcherProgression) GetFilename() string {
 	return "progression.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *CrystalHellProgression) Produce(c chan string) {
+func (p *ResearcherProgression) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
@@ -36,31 +36,31 @@ func (p *CrystalHellProgression) Produce(c chan string) {
 	c <- `</config>`
 }
 
-func (*CrystalHellProgression) getTraitTagsEnhanced() (tags []string) {
+func (*ResearcherProgression) getTraitTagsEnhanced() (tags []string) {
 	for _, plant := range data.Plants {
-		tags = append(tags, fmt.Sprintf("planted%s1_", plant.GetName()))
+		tags = append(tags, plant.GetSchematicName(""))
 	}
 	return
 }
 
-func (*CrystalHellProgression) getTraitTagsSingles() (tags []string) {
+func (*ResearcherProgression) getTraitTagsSingles() (tags []string) {
 	for _, plant := range data.Plants {
 		for _, trait := range data.Traits {
 			if plant.IsCompatibleWith(trait) {
-				tags = append(tags, fmt.Sprintf("planted%s1_%c", plant.GetName(), trait.Code))
+				tags = append(tags, plant.GetSchematicName(string(trait.Code)))
 			}
 		}
 	}
 	return
 }
 
-func (*CrystalHellProgression) getTraitTagsDoubles() (tags []string) {
+func (*ResearcherProgression) getTraitTagsDoubles() (tags []string) {
 	for _, plant := range data.Plants {
 		for _, first := range data.Traits {
 			if plant.IsCompatibleWith(first) {
 				for _, second := range data.Traits {
 					if first.IsCompatibleWith(second) && plant.IsCompatibleWith(second) {
-						tags = append(tags, fmt.Sprintf("planted%s1_%c%c", plant.GetName(), first.Code, second.Code))
+						tags = append(tags, plant.GetSchematicName(string(first.Code)+string(second.Code)))
 					}
 				}
 			}

--- a/gen/progression-standard.go
+++ b/gen/progression-standard.go
@@ -6,21 +6,21 @@ import (
 	"strings"
 )
 
-// VanillaProgression is responsible for producing content for progression.xml
-type VanillaProgression struct{}
+// StandardProgression is responsible for producing content for progression.xml
+type StandardProgression struct{}
 
 // GetPath returns file path for this producer
-func (*VanillaProgression) GetPath() string {
-	return "Config-Vanilla"
+func (*StandardProgression) GetPath() string {
+	return "Config-Standard"
 }
 
 // GetFilename returns filename for this producer
-func (*VanillaProgression) GetFilename() string {
+func (*StandardProgression) GetFilename() string {
 	return "progression.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *VanillaProgression) Produce(c chan string) {
+func (p *StandardProgression) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
@@ -36,31 +36,31 @@ func (p *VanillaProgression) Produce(c chan string) {
 	c <- `</config>`
 }
 
-func (*VanillaProgression) getTraitTagsEnhanced() (tags []string) {
+func (*StandardProgression) getTraitTagsEnhanced() (tags []string) {
 	for _, plant := range data.Plants {
-		tags = append(tags, plant.GetSchematicName(""))
+		tags = append(tags, fmt.Sprintf("planted%s1_", plant.GetName()))
 	}
 	return
 }
 
-func (*VanillaProgression) getTraitTagsSingles() (tags []string) {
+func (*StandardProgression) getTraitTagsSingles() (tags []string) {
 	for _, plant := range data.Plants {
 		for _, trait := range data.Traits {
 			if plant.IsCompatibleWith(trait) {
-				tags = append(tags, plant.GetSchematicName(string(trait.Code)))
+				tags = append(tags, fmt.Sprintf("planted%s1_%c", plant.GetName(), trait.Code))
 			}
 		}
 	}
 	return
 }
 
-func (*VanillaProgression) getTraitTagsDoubles() (tags []string) {
+func (*StandardProgression) getTraitTagsDoubles() (tags []string) {
 	for _, plant := range data.Plants {
 		for _, first := range data.Traits {
 			if plant.IsCompatibleWith(first) {
 				for _, second := range data.Traits {
 					if first.IsCompatibleWith(second) && plant.IsCompatibleWith(second) {
-						tags = append(tags, plant.GetSchematicName(string(first.Code)+string(second.Code)))
+						tags = append(tags, fmt.Sprintf("planted%s1_%c%c", plant.GetName(), first.Code, second.Code))
 					}
 				}
 			}

--- a/gen/progression-standard.go
+++ b/gen/progression-standard.go
@@ -24,6 +24,10 @@ func (p *StandardProgression) Produce(c chan string) {
 	defer close(c)
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='cropHarvest,wildCropsHarvest']/@level">1,2,3,4,5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='cropHarvest,wildCropsHarvest']/@value">1,1,2,2,2</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='bonusCropHarvest']/@level">2,3,4,5</set>`
+	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group/passive_effect[@name='HarvestCount' and @tags='bonusCropHarvest']/@value">1,1,1,1</set>`
 	c <- `<append xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group">
     <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="hotbox" />`
 	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="%s" />`,

--- a/gen/progression-standard.go
+++ b/gen/progression-standard.go
@@ -25,12 +25,12 @@ func (p *StandardProgression) Produce(c chan string) {
 	c <- `<config>`
 	c <- `<set xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/@max_level">5</set>`
 	c <- `<append xpath="/progression/perks/perk[@name='perkLivingOffTheLand']/effect_group">
-    <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3" value="1" tags="hotbox" />`
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3" value="1" tags="%s" />`,
+    <passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="hotbox" />`
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="3,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsEnhanced(), ","))
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="4" value="1" tags="%s" />`,
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="4,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsSingles(), ","))
-	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="5" value="1" tags="%s" />`,
+	c <- fmt.Sprintf(`<passive_effect name="RecipeTagUnlocked" operation="base_set" level="5,5" value="1" tags="%s" />`,
 		strings.Join(p.getTraitTagsDoubles(), ","))
 	c <- `</append>`
 	c <- `</config>`

--- a/gen/recipes-researcher.go
+++ b/gen/recipes-researcher.go
@@ -141,7 +141,7 @@ func (p *ResearcherRecipes) produceSchematicsRecipe(c chan string, plant data.Pl
 			traits[0].Code, traits[1].Code)
 		c <- fmt.Sprintf(`%s
     <ingredient name="resourcePaper" count="10"/>
-    <ingredient name="planted%s1_%c" count="1"/>`,
+    <ingredient name="planted%s1_%c" count="10"/>`,
 			signature, plant.GetName(), traits[0].Code)
 		p.produceSchematicIngredients(c, traits[1])
 		c <- `</recipe>`
@@ -150,7 +150,7 @@ func (p *ResearcherRecipes) produceSchematicsRecipe(c chan string, plant data.Pl
 		}
 		c <- fmt.Sprintf(`%s
     <ingredient name="resourcePaper" count="10"/>
-    <ingredient name="planted%s1_%c" count="1"/>`,
+    <ingredient name="planted%s1_%c" count="10"/>`,
 			signature, plant.GetName(), traits[1].Code)
 		p.produceSchematicIngredients(c, traits[0])
 		c <- `</recipe>`

--- a/gen/recipes-researcher.go
+++ b/gen/recipes-researcher.go
@@ -43,10 +43,12 @@ func (p *ResearcherRecipes) Produce(c chan string) {
 }
 
 func (*ResearcherRecipes) produceHotBoxRecipe(c chan string) {
-	c <- `<recipe name="hotbox" count="1" craft_area="workbench" tags="learnable,workbenchCrafting">
-	<ingredient name="resourceForgedIron" count="50"/>
-	<ingredient name="resourceMechanicalParts" count="8"/>
-	<ingredient name="resourceWood" count="25"/>
+	c <- `<recipe name="hotbox" count="1" craft_time="240" craft_area="workbench" tags="learnable,workbenchCrafting">
+    <ingredient name="resourceForgedIron" count="50"/>
+    <ingredient name="resourceMechanicalParts" count="8"/>
+    <ingredient name="resourceWood" count="25"/>
+    <ingredient name="resourcePotassiumNitratePowder" count="10"/>
+    <ingredient name="resourceClayLump" count="50"/>
 </recipe>`
 }
 
@@ -63,7 +65,7 @@ func (p *ResearcherRecipes) producePlantRecipe(c chan string, plant data.Plant, 
 			plant.GetName(),
 			enhancedSeedCraftTime,
 			plant.GetName())
-		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox" tags="learnable">
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" tags="learnable" craft_area="hotbox">
     <ingredient name="planted%s1" count="1"/>
     <ingredient name="foodRottingFlesh" count="1"/>
 </recipe>`,
@@ -71,7 +73,7 @@ func (p *ResearcherRecipes) producePlantRecipe(c chan string, plant data.Plant, 
 			enhancedSeedCraftTime,
 			plant.GetName())
 	case 1:
-		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" craft_area="hotbox" tags="learnable">
+		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" tags="learnable" craft_area="hotbox">
     <ingredient name="planted%s1_" count="1"/>`,
 			plant.GetName(),
 			traits[0].Code,
@@ -81,7 +83,7 @@ func (p *ResearcherRecipes) producePlantRecipe(c chan string, plant data.Plant, 
 		p.producePlantIngredients(c, traits[0])
 		c <- `</recipe>`
 	case 2: // support bi-directional recipes
-		signature := fmt.Sprintf(`<recipe name="planted%s1_%c%c" count="1" craft_time="%d" traits="%c%c" craft_area="hotbox" tags="learnable">`,
+		signature := fmt.Sprintf(`<recipe name="planted%s1_%c%c" count="1" craft_time="%d" traits="%c%c" tags="learnable" craft_area="hotbox">`,
 			plant.GetName(),
 			traits[0].Code, traits[1].Code,
 			plant.GetCraftTime(),

--- a/gen/recipes-researcher.go
+++ b/gen/recipes-researcher.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// VanillaRecipes is responsible for producing content for recipes.xml
-type VanillaRecipes struct{}
+// ResearcherRecipes is responsible for producing content for recipes.xml
+type ResearcherRecipes struct{}
 
 // GetPath returns file path for this producer
-func (*VanillaRecipes) GetPath() string {
-	return "Config-Vanilla"
+func (*ResearcherRecipes) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (*VanillaRecipes) GetFilename() string {
+func (*ResearcherRecipes) GetFilename() string {
 	return "recipes.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *VanillaRecipes) Produce(c chan string) {
+func (p *ResearcherRecipes) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/recipes">`
 	p.produceHotBoxRecipe(c)
@@ -42,7 +42,7 @@ func (p *VanillaRecipes) Produce(c chan string) {
 	c <- `</append></config>`
 }
 
-func (*VanillaRecipes) produceHotBoxRecipe(c chan string) {
+func (*ResearcherRecipes) produceHotBoxRecipe(c chan string) {
 	c <- `<recipe name="hotbox" count="1" craft_area="workbench" tags="learnable,workbenchCrafting">
 	<ingredient name="resourceForgedIron" count="50"/>
 	<ingredient name="resourceMechanicalParts" count="8"/>
@@ -50,7 +50,7 @@ func (*VanillaRecipes) produceHotBoxRecipe(c chan string) {
 </recipe>`
 }
 
-func (p *VanillaRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
+func (p *ResearcherRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
 		enhancedSeedCraftTime := plant.GetCraftTime() * 450
@@ -106,7 +106,7 @@ func (p *VanillaRecipes) producePlantRecipe(c chan string, plant data.Plant, tra
 	}
 }
 
-func (*VanillaRecipes) producePlantIngredients(c chan string, trait data.Trait) {
+func (*ResearcherRecipes) producePlantIngredients(c chan string, trait data.Trait) {
 	for _, ingredient := range trait.Ingredients {
 		c <- fmt.Sprintf(`    <ingredient name="%s" count="%d"/>`,
 			ingredient.Name,
@@ -114,7 +114,7 @@ func (*VanillaRecipes) producePlantIngredients(c chan string, trait data.Trait) 
 	}
 }
 
-func (p *VanillaRecipes) produceSchematicsRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
+func (p *ResearcherRecipes) produceSchematicsRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
 		c <- fmt.Sprintf(`<recipe name="%s" count="1" craft_time="10" traits="" craft_area="hotbox" tags="learnable">
@@ -155,7 +155,7 @@ func (p *VanillaRecipes) produceSchematicsRecipe(c chan string, plant data.Plant
 	}
 }
 
-func (*VanillaRecipes) produceSchematicIngredients(c chan string, trait data.Trait) {
+func (*ResearcherRecipes) produceSchematicIngredients(c chan string, trait data.Trait) {
 	for _, ingredient := range trait.Ingredients {
 		c <- fmt.Sprintf(`    <ingredient name="%s" count="%d"/>`,
 			ingredient.Name,

--- a/gen/recipes-researcher.go
+++ b/gen/recipes-researcher.go
@@ -122,7 +122,7 @@ func (p *ResearcherRecipes) produceSchematicsRecipe(c chan string, plant data.Pl
 		c <- fmt.Sprintf(`<recipe name="%s" count="1" craft_time="10" traits="" craft_area="hotbox" tags="learnable">
     <ingredient name="resourcePaper" count="10"/>
     <ingredient name="planted%s1" count="100"/>
-	<ingredient name="foodRottingFlesh" count="100"/>
+    <ingredient name="foodRottingFlesh" count="100"/>
 </recipe>`,
 			plant.GetSchematicName(""),
 			plant.GetName())

--- a/gen/recipes-standard.go
+++ b/gen/recipes-standard.go
@@ -41,10 +41,12 @@ func (p *StandardRecipes) Produce(c chan string) {
 }
 
 func (*StandardRecipes) produceHotBoxRecipe(c chan string) {
-	c <- `<recipe name="hotbox" count="1" craft_area="workbench" tags="learnable,workbenchCrafting">
-	<ingredient name="resourceForgedIron" count="50"/>
-	<ingredient name="resourceMechanicalParts" count="8"/>
-	<ingredient name="resourceWood" count="25"/>
+	c <- `<recipe name="hotbox" count="1" craft_time="240" craft_area="workbench" tags="learnable,workbenchCrafting">
+    <ingredient name="resourceForgedIron" count="50"/>
+    <ingredient name="resourceMechanicalParts" count="8"/>
+    <ingredient name="resourceWood" count="25"/>
+    <ingredient name="resourcePotassiumNitratePowder" count="10"/>
+    <ingredient name="resourceClayLump" count="50"/>
 </recipe>`
 }
 
@@ -52,7 +54,7 @@ func (p *StandardRecipes) producePlantRecipe(c chan string, plant data.Plant, tr
 	switch len(traits) {
 	case 0:
 		enhancedSeedCraftTime := plant.GetCraftTime() * 450
-		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="">
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" tags="learnable">
     <ingredient name="planted%s1" count="1"/>
     <ingredient name="foodRottingFlesh" count="1"/>
     <ingredient name="resourceCloth" count="1"/>
@@ -61,7 +63,7 @@ func (p *StandardRecipes) producePlantRecipe(c chan string, plant data.Plant, tr
 			plant.GetName(),
 			enhancedSeedCraftTime,
 			plant.GetName())
-		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox">
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" tags="learnable" craft_area="hotbox">
     <ingredient name="planted%s1" count="1"/>
     <ingredient name="foodRottingFlesh" count="1"/>
 </recipe>`,
@@ -69,7 +71,7 @@ func (p *StandardRecipes) producePlantRecipe(c chan string, plant data.Plant, tr
 			enhancedSeedCraftTime,
 			plant.GetName())
 	case 1:
-		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" craft_area="hotbox">
+		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" tags="learnable" craft_area="hotbox">
     <ingredient name="planted%s1_" count="1"/>`,
 			plant.GetName(),
 			traits[0].Code,
@@ -79,7 +81,7 @@ func (p *StandardRecipes) producePlantRecipe(c chan string, plant data.Plant, tr
 		p.producePlantIngredients(c, traits[0])
 		c <- `</recipe>`
 	case 2: // support bi-directional recipes
-		signature := fmt.Sprintf(`<recipe name="planted%s1_%c%c" count="1" craft_time="%d" traits="%c%c" craft_area="hotbox">`,
+		signature := fmt.Sprintf(`<recipe name="planted%s1_%c%c" count="1" craft_time="%d" traits="%c%c" tags="learnable" craft_area="hotbox">`,
 			plant.GetName(),
 			traits[0].Code, traits[1].Code,
 			plant.GetCraftTime(),

--- a/gen/recipes-standard.go
+++ b/gen/recipes-standard.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-// CrystalHellRecipes is responsible for producing content for recipes.xml
-type CrystalHellRecipes struct{}
+// StandardRecipes is responsible for producing content for recipes.xml
+type StandardRecipes struct{}
 
 // GetPath returns file path for this producer
-func (*CrystalHellRecipes) GetPath() string {
-	return "Config-CrystalHell"
+func (*StandardRecipes) GetPath() string {
+	return "Config-Standard"
 }
 
 // GetFilename returns filename for this producer
-func (*CrystalHellRecipes) GetFilename() string {
+func (*StandardRecipes) GetFilename() string {
 	return "recipes.xml"
 }
 
 // Produce xml data to the provided channel
-func (p *CrystalHellRecipes) Produce(c chan string) {
+func (p *StandardRecipes) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/recipes">`
 	p.produceHotBoxRecipe(c)
@@ -40,7 +40,7 @@ func (p *CrystalHellRecipes) Produce(c chan string) {
 
 }
 
-func (*CrystalHellRecipes) produceHotBoxRecipe(c chan string) {
+func (*StandardRecipes) produceHotBoxRecipe(c chan string) {
 	c <- `<recipe name="hotbox" count="1" craft_area="workbench" tags="learnable,workbenchCrafting">
 	<ingredient name="resourceForgedIron" count="50"/>
 	<ingredient name="resourceMechanicalParts" count="8"/>
@@ -48,7 +48,7 @@ func (*CrystalHellRecipes) produceHotBoxRecipe(c chan string) {
 </recipe>`
 }
 
-func (p *CrystalHellRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
+func (p *StandardRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
 		enhancedSeedCraftTime := plant.GetCraftTime() * 450
@@ -104,7 +104,7 @@ func (p *CrystalHellRecipes) producePlantRecipe(c chan string, plant data.Plant,
 	}
 }
 
-func (p *CrystalHellRecipes) producePlantIngredients(c chan string, trait data.Trait) {
+func (p *StandardRecipes) producePlantIngredients(c chan string, trait data.Trait) {
 	for _, ingredient := range trait.Ingredients {
 		c <- fmt.Sprintf(`    <ingredient name="%s" count="%d"/>`,
 			ingredient.Name,

--- a/gen/ui_display-researcher.go
+++ b/gen/ui_display-researcher.go
@@ -17,7 +17,7 @@ func (*ResearcherUIDisplay) GetFilename() string {
 func (*ResearcherUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
-        <crafting_category_list display_type="hotbox">
+    <crafting_category_list display_type="hotbox">
         <crafting_category name="Tier1SeedResearch" icon="ui_game_symbol_book" display_name="lblCategoryTier1SeedResearch" />
         <crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
         <crafting_category name="Tier2SeedResearch" icon="ui_game_symbol_book" display_name="lblCategoryTier2SeedResearch" />

--- a/gen/ui_display-researcher.go
+++ b/gen/ui_display-researcher.go
@@ -1,20 +1,20 @@
 package gen
 
-// VanillaUIDisplay is responsible for producing content for ui_display.xml
-type VanillaUIDisplay struct{}
+// ResearcherUIDisplay is responsible for producing content for ui_display.xml
+type ResearcherUIDisplay struct{}
 
 // GetPath returns file path for this producer
-func (*VanillaUIDisplay) GetPath() string {
-	return "Config-Vanilla"
+func (*ResearcherUIDisplay) GetPath() string {
+	return "Config-Researcher"
 }
 
 // GetFilename returns filename for this producer
-func (*VanillaUIDisplay) GetFilename() string {
+func (*ResearcherUIDisplay) GetFilename() string {
 	return "ui_display.xml"
 }
 
 // Produce xml data to the provided channel
-func (*VanillaUIDisplay) Produce(c chan string) {
+func (*ResearcherUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
         <crafting_category_list display_type="hotbox">

--- a/gen/ui_display-standard.go
+++ b/gen/ui_display-standard.go
@@ -17,7 +17,7 @@ func (*StandardUIDisplay) GetFilename() string {
 func (*StandardUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
-        <crafting_category_list display_type="hotbox">
+    <crafting_category_list display_type="hotbox">
         <crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
         <crafting_category name="Tier2Seeds" icon="ui_game_symbol_add" display_name="lblCategoryTier2Seeds" />
         <crafting_category name="Tier3Seeds" icon="ui_game_symbol_healing_factor" display_name="lblCategoryTier3Seeds" />

--- a/gen/ui_display-standard.go
+++ b/gen/ui_display-standard.go
@@ -18,9 +18,9 @@ func (*StandardUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
         <crafting_category_list display_type="hotbox">
-		<crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
-		<crafting_category name="Tier2Seeds" icon="ui_game_symbol_add" display_name="lblCategoryTier2Seeds" />
-		<crafting_category name="Tier3Seeds" icon="ui_game_symbol_healing_factor" display_name="lblCategoryTier3Seeds" />
+        <crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
+        <crafting_category name="Tier2Seeds" icon="ui_game_symbol_add" display_name="lblCategoryTier2Seeds" />
+        <crafting_category name="Tier3Seeds" icon="ui_game_symbol_healing_factor" display_name="lblCategoryTier3Seeds" />
     </crafting_category_list>
 </append></config>`
 }

--- a/gen/ui_display-standard.go
+++ b/gen/ui_display-standard.go
@@ -1,20 +1,20 @@
 package gen
 
-// CrystalHellUIDisplay is responsible for producing content for ui_display.xml
-type CrystalHellUIDisplay struct{}
+// StandardUIDisplay is responsible for producing content for ui_display.xml
+type StandardUIDisplay struct{}
 
 // GetPath returns file path for this producer
-func (*CrystalHellUIDisplay) GetPath() string {
-	return "Config-CrystalHell"
+func (*StandardUIDisplay) GetPath() string {
+	return "Config-Standard"
 }
 
 // GetFilename returns filename for this producer
-func (*CrystalHellUIDisplay) GetFilename() string {
+func (*StandardUIDisplay) GetFilename() string {
 	return "ui_display.xml"
 }
 
 // Produce xml data to the provided channel
-func (*CrystalHellUIDisplay) Produce(c chan string) {
+func (*StandardUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
         <crafting_category_list display_type="hotbox">

--- a/gen/utils.go
+++ b/gen/utils.go
@@ -23,10 +23,14 @@ func Write(producer Producer) error {
 }
 
 func getFile(path, filename string) (*os.File, error) {
+	pathAndFilename := fmt.Sprintf("%s%c%s", path, os.PathSeparator, filename)
+	if err := os.Remove(pathAndFilename); err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(fmt.Sprintf("%s%c%s", path, os.PathSeparator, filename), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0755)
+	return os.OpenFile(pathAndFilename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0755)
 }
 
 func getEnhancedSeedEffectDescription() string {

--- a/gen/vanilla-recipes.go
+++ b/gen/vanilla-recipes.go
@@ -53,14 +53,22 @@ func (*VanillaRecipes) produceHotBoxRecipe(c chan string) {
 func (p *VanillaRecipes) producePlantRecipe(c chan string, plant data.Plant, traits ...data.Trait) {
 	switch len(traits) {
 	case 0:
-		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox" tags="learnable">
+		enhancedSeedCraftTime := plant.GetCraftTime() * 450
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" tags="learnable">
     <ingredient name="planted%s1" count="1"/>
     <ingredient name="foodRottingFlesh" count="1"/>
     <ingredient name="resourceCloth" count="1"/>
     <ingredient name="resourceYuccaFibers" count="2"/>
 </recipe>`,
 			plant.GetName(),
-			plant.GetCraftTime()*450,
+			enhancedSeedCraftTime,
+			plant.GetName())
+		c <- fmt.Sprintf(`<recipe name="planted%s1_" count="1" craft_time="%d" traits="" craft_area="hotbox" tags="learnable">
+    <ingredient name="planted%s1" count="1"/>
+    <ingredient name="foodRottingFlesh" count="1"/>
+</recipe>`,
+			plant.GetName(),
+			enhancedSeedCraftTime,
 			plant.GetName())
 	case 1:
 		c <- fmt.Sprintf(`<recipe name="planted%s1_%c" count="1" craft_time="%d" traits="%c" craft_area="hotbox" tags="learnable">

--- a/main.go
+++ b/main.go
@@ -8,17 +8,17 @@ import (
 
 func main() {
 	for _, producer := range []gen.Producer{
-		&gen.StandardBlocks{},
-		&gen.StandardLocalization{},
-		&gen.StandardProgression{},
-		&gen.StandardRecipes{},
-		&gen.StandardUIDisplay{},
 		&gen.ResearcherBlocks{},
 		&gen.ResearcherItems{},
 		&gen.ResearcherLocalization{},
 		&gen.ResearcherProgression{},
 		&gen.ResearcherRecipes{},
 		&gen.ResearcherUIDisplay{},
+		&gen.StandardBlocks{},
+		&gen.StandardLocalization{},
+		&gen.StandardProgression{},
+		&gen.StandardRecipes{},
+		&gen.StandardUIDisplay{},
 	} {
 		if err := gen.Write(producer); err != nil {
 			fmt.Printf("ERROR: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -8,17 +8,17 @@ import (
 
 func main() {
 	for _, producer := range []gen.Producer{
-		&gen.CrystalHellBlocks{},
-		&gen.CrystalHellLocalization{},
-		&gen.CrystalHellProgression{},
-		&gen.CrystalHellRecipes{},
-		&gen.CrystalHellUIDisplay{},
-		&gen.VanillaBlocks{},
-		&gen.VanillaItems{},
-		&gen.VanillaLocalization{},
-		&gen.VanillaProgression{},
-		&gen.VanillaRecipes{},
-		&gen.VanillaUIDisplay{},
+		&gen.StandardBlocks{},
+		&gen.StandardLocalization{},
+		&gen.StandardProgression{},
+		&gen.StandardRecipes{},
+		&gen.StandardUIDisplay{},
+		&gen.ResearcherBlocks{},
+		&gen.ResearcherItems{},
+		&gen.ResearcherLocalization{},
+		&gen.ResearcherProgression{},
+		&gen.ResearcherRecipes{},
+		&gen.ResearcherUIDisplay{},
 	} {
 		if err := gen.Write(producer); err != nil {
 			fmt.Printf("ERROR: %v\n", err)


### PR DESCRIPTION
## Summary
- remove seed return chance during harvest
- add recipe for enhanced seed crafting by hand
- rename vanilla->researcher, crystal-hell->standard
- fix file generation
- fix schematic recipe unlocks, update hotbox recipe
- fix standard recipe unlocks, update hotbox recipe
- hide fully grown plant types
- hide growing plant types
- fix gracecorn stage 2 model
- set hotbox repair resources
- resolve issue with explosive trait collision
- update readme
- make Thorny and Explosive traits incompatible
- fix perk level descriptions, add [MOD] indicator
- fix bonus trait; support for higher lotl levels
- fix researcher 2nd trait seed ingredient count