### PR TITLE
Add Seed Glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2022-06-07
+
+- update hotbox enhancement category icon to upgrade
+
 ## [1.0.1] - 2022-05-28
 
 - fix bug with remembering seed unlocks after lvl 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2022-06-07
 
 - update hotbox enhancement category icon to upgrade
+- add icon glyphs to each seed type
 
 ## [1.0.1] - 2022-05-28
 

--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -3,7 +3,7 @@
         <Name value="GMO Farming" />
         <Description value="Genetically modify seeds to grow plants with new properties" />
         <Author value="Jonathan Robertson (Kanaverum) and Shavick" />
-        <Version value="1.0.1" />
+        <Version value="1.1.0" />
         <Website value="https://github.com/jonathan-robertson/gmo-farming" />
     </ModInfo>
 </xml>

--- a/data/aloe.go
+++ b/data/aloe.go
@@ -64,6 +64,7 @@ func (p *Aloe) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedAloe1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedAloe1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedAloe1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -73,7 +74,7 @@ func (p *Aloe) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedAloe2_%s"/>
     <property name="Shape" value="ModelEntity"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Aloe) writeStage2(c chan string, traits string) {
@@ -97,6 +98,7 @@ func (p *Aloe) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedAloe1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedAloe3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -124,5 +126,6 @@ func (p *Aloe) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/blueberry.go
+++ b/data/blueberry.go
@@ -64,6 +64,7 @@ func (p *Blueberry) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedBlueberry1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedBlueberry1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedBlueberry1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -72,7 +73,7 @@ func (p *Blueberry) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedBlueberry2_%s"/>
     <property name="Shape" value="ModelEntity"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Blueberry) writeStage2(c chan string, traits string) {
@@ -96,6 +97,7 @@ func (p *Blueberry) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedBlueberry1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedBlueberry3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -122,5 +124,6 @@ func (p *Blueberry) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/chrysanthemum.go
+++ b/data/chrysanthemum.go
@@ -64,6 +64,7 @@ func (p *Chrysanthemum) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedChrysanthemum1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedChrysanthemum1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedChrysanthemum1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -71,7 +72,7 @@ func (p *Chrysanthemum) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedChrysanthemum2_%s"/>
     <property name="Texture" value="550"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Chrysanthemum) writeStage2(c chan string, traits string) {
@@ -95,6 +96,7 @@ func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedChrysanthemum1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedChrysanthemum3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -119,5 +121,6 @@ func (p *Chrysanthemum) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/coffee.go
+++ b/data/coffee.go
@@ -65,6 +65,7 @@ func (p *Coffee) writeStage1(c chan string, target, traits string) {
     <property name="CraftingIngredientTime" value="5"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedCoffee1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedCoffee1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -72,7 +73,7 @@ func (p *Coffee) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedCoffee2_%s"/>
     <property name="Texture" value="393"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Coffee) writeStage2(c chan string, traits string) {
@@ -96,6 +97,7 @@ func (p *Coffee) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedCoffee1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedCoffee3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -121,5 +123,6 @@ func (p *Coffee) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/corn.go
+++ b/data/corn.go
@@ -66,6 +66,7 @@ func (p *Corn) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedCorn1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedCorn1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -79,7 +80,7 @@ func (p *Corn) writeStage1(c chan string, target, traits string) {
     <property name="Shape" value="New"/>
     <property name="Texture" value="529"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Corn) writeStage2(c chan string, traits string) {
@@ -104,6 +105,7 @@ func (p *Corn) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedCorn3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -130,5 +132,6 @@ func (p *Corn) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/cotton.go
+++ b/data/cotton.go
@@ -64,6 +64,7 @@ func (p *Cotton) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedCotton1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedCotton1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedCotton1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -71,7 +72,7 @@ func (p *Cotton) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedCotton2_%s"/>
     <property name="Texture" value="392"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Cotton) writeStage2(c chan string, traits string) {
@@ -95,6 +96,7 @@ func (p *Cotton) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedCotton1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedCotton3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -120,5 +122,6 @@ func (p *Cotton) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/goldenrod.go
+++ b/data/goldenrod.go
@@ -64,6 +64,7 @@ func (p *Goldenrod) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedGoldenrod1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedGoldenrod1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedGoldenrod1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster"/>
     <property name="Group" value="%s"/>
@@ -71,7 +72,7 @@ func (p *Goldenrod) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedGoldenrod2_%s"/>
     <property name="Texture" value="401"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Goldenrod) writeStage2(c chan string, traits string) {
@@ -95,6 +96,7 @@ func (p *Goldenrod) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedGoldenrod1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedGoldenrod3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -120,5 +122,6 @@ func (p *Goldenrod) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/gracecorn.go
+++ b/data/gracecorn.go
@@ -64,6 +64,7 @@ func (p *GraceCorn) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedGraceCorn1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff9f9f"/>
     <property name="DescriptionKey" value="plantedGraceCorn1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
@@ -78,7 +79,7 @@ func (p *GraceCorn) writeStage1(c chan string, target, traits string) {
     <property name="Shape" value="New"/>
     <property name="Texture" value="529"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*GraceCorn) writeStage2(c chan string, traits string) {
@@ -103,6 +104,7 @@ func (p *GraceCorn) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedCorn1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8f9f"/>
     <property name="DescriptionKey" value="plantedGraceCorn3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -129,5 +131,6 @@ func (p *GraceCorn) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/hop.go
+++ b/data/hop.go
@@ -64,6 +64,7 @@ func (p *Hop) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedHop1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedHop1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedHop1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -71,7 +72,7 @@ func (p *Hop) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedHop2_%s"/>
     <property name="Texture" value="447"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Hop) writeStage2(c chan string, traits string) {
@@ -95,6 +96,7 @@ func (p *Hop) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedHop1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedHop3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -121,5 +123,6 @@ func (p *Hop) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/mushroom.go
+++ b/data/mushroom.go
@@ -67,6 +67,7 @@ func (p *Mushroom) writeStage1(c chan string, target, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedMushroom1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedMushroom1_%sDesc"/>
     <property name="DisplayInfo" value="Name"/>
     <property name="EconomicBundleSize" value="5"/>
@@ -87,7 +88,7 @@ func (p *Mushroom) writeStage1(c chan string, target, traits string) {
     <property name="Shape" value="Ext3dModel"/>
     <property name="Texture" value="293"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Mushroom) writeStage2(c chan string, traits string) {
@@ -113,6 +114,7 @@ func (p *Mushroom) writeStage3(c chan string, traits string) {
     <property name="CreativeMode" value="Dev"/>
     <property name="CropsGrown.BonusHarvestDivisor" value="16"/>
     <property name="CustomIcon" value="plantedMushroom1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedMushroom3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -135,5 +137,6 @@ func (p *Mushroom) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/plant.go
+++ b/data/plant.go
@@ -161,3 +161,16 @@ func getDefaultSeedDescription() string {
 func getCraftingGroup(traits string) string {
 	return fmt.Sprintf("Tier%dSeeds", len(traits)+1)
 }
+
+func getItemTypeIcon(traits string) string {
+	switch len(traits) {
+	case 0:
+		return "block_upgrade"
+	case 1:
+		return "add"
+	case 2:
+		return "healing_factor"
+	default:
+		return ""
+	}
+}

--- a/data/potato.go
+++ b/data/potato.go
@@ -64,6 +64,7 @@ func (p *Potato) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedPotato1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedPotato1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedPotato1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -72,7 +73,7 @@ func (p *Potato) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedPotato2_%s"/>
     <property name="Shape" value="ModelEntity"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Potato) writeStage2(c chan string, traits string) {
@@ -96,6 +97,7 @@ func (p *Potato) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedPotato1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedPotato3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -123,5 +125,6 @@ func (p *Potato) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/pumpkin.go
+++ b/data/pumpkin.go
@@ -64,6 +64,7 @@ func (p *Pumpkin) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedPumpkin1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedPumpkin1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedPumpkin1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -73,7 +74,7 @@ func (p *Pumpkin) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedPumpkin2_%s"/>
     <property name="Shape" value="ModelEntity"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Pumpkin) writeStage2(c chan string, traits string) {
@@ -97,6 +98,7 @@ func (p *Pumpkin) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedPumpkin1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedPumpkin3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -126,5 +128,6 @@ func (p *Pumpkin) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/data/yucca.go
+++ b/data/yucca.go
@@ -64,6 +64,7 @@ func (p *Yucca) writeStage1(c chan string, target, traits string) {
     <drop event="Destroy" name="plantedYucca1_%s" count="1"/>
     <property name="CreativeMode" value="Player"/>
     <property name="CustomIcon" value="plantedYucca1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="DescriptionKey" value="plantedYucca1_%sDesc"/>
     <property name="Extends" value="cropsGrowingMaster" param1="CustomIcon"/>
     <property name="Group" value="%s"/>
@@ -73,7 +74,7 @@ func (p *Yucca) writeStage1(c chan string, target, traits string) {
     <property name="PlantGrowing.Next" value="plantedYucca2_%s"/>
     <property name="Shape" value="ModelEntity"/>
     <property name="UnlockedBy" value="%s"/>
-</block>`, traits, traits, traits, traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
+</block>`, traits, traits, traits, getItemTypeIcon(traits), traits, getCraftingGroup(traits), traits, getUnlock(p, target, traits))
 }
 
 func (*Yucca) writeStage2(c chan string, traits string) {
@@ -97,6 +98,7 @@ func (p *Yucca) writeStage3(c chan string, traits string) {
     <property name="Collide" value="melee"/>
     <property name="CreativeMode" value="Dev"/>
     <property name="CustomIcon" value="plantedYucca1"/>
+    <property name="ItemTypeIcon" value="%s"/>
     <property name="CustomIconTint" value="ff8000"/>
     <property name="DescriptionKey" value="plantedYucca3HarvestDesc"/>
     <property name="DisplayInfo" value="Description"/>
@@ -123,5 +125,6 @@ func (p *Yucca) writeStage3(c chan string, traits string) {
 		calculatePlantTier(traits),
 		calculateCropYield(p.CropYield, traits),
 		calculateBonusYield(p.BonusYield, traits),
+		getItemTypeIcon(traits),
 		optionallyAddRenewable(traits, p))
 }

--- a/gen/ui_display-researcher.go
+++ b/gen/ui_display-researcher.go
@@ -19,7 +19,7 @@ func (*ResearcherUIDisplay) Produce(c chan string) {
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
     <crafting_category_list display_type="hotbox">
         <crafting_category name="Tier1SeedResearch" icon="ui_game_symbol_book" display_name="lblCategoryTier1SeedResearch" />
-        <crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
+        <crafting_category name="Tier1Seeds" icon="ui_game_symbol_block_upgrade" display_name="lblCategoryTier1Seeds" />
         <crafting_category name="Tier2SeedResearch" icon="ui_game_symbol_book" display_name="lblCategoryTier2SeedResearch" />
         <crafting_category name="Tier2Seeds" icon="ui_game_symbol_add" display_name="lblCategoryTier2Seeds" />
         <crafting_category name="Tier3SeedResearch" icon="ui_game_symbol_book" display_name="lblCategoryTier3SeedResearch" />

--- a/gen/ui_display-standard.go
+++ b/gen/ui_display-standard.go
@@ -18,7 +18,7 @@ func (*StandardUIDisplay) Produce(c chan string) {
 	defer close(c)
 	c <- `<config><append xpath="/ui_display_info/crafting_category_display">
     <crafting_category_list display_type="hotbox">
-        <crafting_category name="Tier1Seeds" icon="ui_game_symbol_crops" display_name="lblCategoryTier1Seeds" />
+        <crafting_category name="Tier1Seeds" icon="ui_game_symbol_block_upgrade" display_name="lblCategoryTier1Seeds" />
         <crafting_category name="Tier2Seeds" icon="ui_game_symbol_add" display_name="lblCategoryTier2Seeds" />
         <crafting_category name="Tier3Seeds" icon="ui_game_symbol_healing_factor" display_name="lblCategoryTier3Seeds" />
     </crafting_category_list>


### PR DESCRIPTION
## Summary
This should help to make it easier to see enhanced or modded seeds at a glance in your inventory.

- update hotbox enhancement category icon to upgrade
- add icon glyphs to each seed type